### PR TITLE
Log unanswered questions

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -356,6 +356,13 @@ app.get('/analytics', requireAdmin, async (req, res) => {
   res.render('analytics', { stats: rows });
 });
 
+app.get('/unanswered', requireAdmin, async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT phone, message, created_at FROM unanswered_questions ORDER BY created_at DESC'
+  );
+  res.render('unanswered', { alerts: rows });
+});
+
 function startAdminServer() {
   const port = process.env.ADMIN_PORT || 3001;
   statusInterval = setInterval(broadcastStatus, 5000);

--- a/src/initDb.js
+++ b/src/initDb.js
@@ -109,6 +109,15 @@ async function init() {
   `);
 
   await pool.query(`
+    CREATE TABLE IF NOT EXISTS unanswered_questions (
+      id SERIAL PRIMARY KEY,
+      phone TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(`
     CREATE TABLE IF NOT EXISTS users (
       id SERIAL PRIMARY KEY,
       username TEXT UNIQUE NOT NULL,

--- a/src/worker.js
+++ b/src/worker.js
@@ -88,6 +88,12 @@ const worker = new Worker(
     }
     try {
       const reply = await sendMessage(orgId, assistantId, sender, text);
+      if (/لا أفهم|غير واضح/.test(reply)) {
+        await pool.query(
+          'INSERT INTO unanswered_questions (phone, message) VALUES ($1,$2)',
+          [sender, text]
+        );
+      }
       const { rows } = await pool.query(
         'SELECT id FROM conversations WHERE organization_id=$1 AND customer_phone=$2 ORDER BY id DESC LIMIT 1',
         [orgId, sender]

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -117,4 +117,10 @@ describe('admin routes', () => {
       phones: ['1', '2'],
     });
   });
+
+  it('serves unanswered questions page', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').send('username=admin&password=secret&token=123456');
+    await agent.get('/unanswered').expect(200);
+  });
 });

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -13,6 +13,7 @@
 <a href="/dashboard">Dashboard</a>
 <a href="/schedule/new">Schedule Message</a>
 <a href="/broadcast">Broadcast</a>
+<a href="/unanswered">Unanswered</a>
 <ul>
 <% orgs.forEach(function(o){ %>
   <li>

--- a/views/unanswered.ejs
+++ b/views/unanswered.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Unanswered Questions</title>
+</head>
+<body>
+<h1>Unanswered Questions</h1>
+<a href="/">Back</a>
+<ul>
+  <% alerts.forEach(function(a){ %>
+    <li>
+      <%= a.created_at.toISOString().slice(0,16).replace('T',' ') %> |
+      <%= a.phone %> : <%= a.message %>
+    </li>
+  <% }); %>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `unanswered_questions` table
- detect unclear replies in `worker.js`
- expose `/unanswered` page in admin panel
- link unanswered page from org list
- test unanswered page route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896ac37db8833198c6b43e9a3d9ee7