### PR TITLE
Add FAQ suggestion generator and admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@
    npm run worker
    ```
 
+10. توليد اقتراحات الأسئلة المتكررة:
+   ```bash
+   npm run generate-faq
+   ```
+
 ## بنية المجلد `src/`
 - `db.js` – إعداد اتصال PostgreSQL.
 - `openai.js` – تهيئة عميل OpenAI ليعمل مع الإصدارات المختلفة.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node src/index.js",
     "create-assistant": "node src/scripts/createAssistant.js",
     "upload-file": "node src/scripts/uploadFile.js",
+    "generate-faq": "node src/scripts/generateFaq.js",
     "whatsapp": "node src/whatsappBot.js",
     "admin": "node src/admin.js",
     "worker": "node src/worker.js"

--- a/src/admin.js
+++ b/src/admin.js
@@ -363,6 +363,18 @@ app.get('/unanswered', requireAdmin, async (req, res) => {
   res.render('unanswered', { alerts: rows });
 });
 
+app.get('/faq', requireAdmin, async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT id, question, count FROM faq_suggestions ORDER BY count DESC'
+  );
+  res.render('faq', { faqs: rows });
+});
+
+app.post('/faq/:id/delete', requireAdmin, async (req, res) => {
+  await pool.query('DELETE FROM faq_suggestions WHERE id=$1', [req.params.id]);
+  res.redirect('/faq');
+});
+
 function startAdminServer() {
   const port = process.env.ADMIN_PORT || 3001;
   statusInterval = setInterval(broadcastStatus, 5000);

--- a/src/initDb.js
+++ b/src/initDb.js
@@ -118,6 +118,15 @@ async function init() {
   `);
 
   await pool.query(`
+    CREATE TABLE IF NOT EXISTS faq_suggestions (
+      id SERIAL PRIMARY KEY,
+      question TEXT UNIQUE NOT NULL,
+      count INTEGER NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(`
     CREATE TABLE IF NOT EXISTS users (
       id SERIAL PRIMARY KEY,
       username TEXT UNIQUE NOT NULL,

--- a/src/scripts/generateFaq.js
+++ b/src/scripts/generateFaq.js
@@ -1,0 +1,36 @@
+const pool = require('../db');
+const logger = require('../logger');
+
+async function generateFaq(limit = 20) {
+  const { rows } = await pool.query(
+    `SELECT lower(trim(text)) AS question, COUNT(*) AS count
+       FROM messages
+      WHERE sender='user' AND (text LIKE '%?' OR text LIKE '%؟%')
+      GROUP BY question
+      ORDER BY count DESC
+      LIMIT $1`,
+    [limit]
+  );
+  await pool.query('TRUNCATE faq_suggestions');
+  for (const row of rows) {
+    await pool.query(
+      'INSERT INTO faq_suggestions (question, count) VALUES ($1,$2)',
+      [row.question, row.count]
+    );
+  }
+  logger.info('FAQ suggestions generated');
+}
+
+async function main() {
+  await generateFaq();
+  process.exit();
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    logger.error('Failed to generate FAQ:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { generateFaq };

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -123,4 +123,17 @@ describe('admin routes', () => {
     await agent.post('/login').send('username=admin&password=secret&token=123456');
     await agent.get('/unanswered').expect(200);
   });
+
+  it('serves faq suggestions page', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').send('username=admin&password=secret&token=123456');
+    await agent.get('/faq').expect(200);
+  });
+
+  it('deletes faq suggestion', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').send('username=admin&password=secret&token=123456');
+    await agent.post('/faq/1/delete').expect(302);
+    expect(pool.query).toHaveBeenCalledWith('DELETE FROM faq_suggestions WHERE id=$1', ['1']);
+  });
 });

--- a/views/faq.ejs
+++ b/views/faq.ejs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>FAQ Suggestions</title>
+</head>
+<body>
+<h1>FAQ Suggestions</h1>
+<a href="/">Back</a>
+<table border="1">
+  <tr>
+    <th>Question</th>
+    <th>Count</th>
+    <th></th>
+  </tr>
+  <% faqs.forEach(function(f){ %>
+  <tr>
+    <td><%= f.question %></td>
+    <td><%= f.count %></td>
+    <td>
+      <form action="/faq/<%= f.id %>/delete" method="post">
+        <button type="submit">Delete</button>
+      </form>
+    </td>
+  </tr>
+  <% }); %>
+</table>
+</body>
+</html>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -14,6 +14,7 @@
 <a href="/schedule/new">Schedule Message</a>
 <a href="/broadcast">Broadcast</a>
 <a href="/unanswered">Unanswered</a>
+<a href="/faq">FAQ Suggestions</a>
 <ul>
 <% orgs.forEach(function(o){ %>
   <li>


### PR DESCRIPTION
## Summary
- create DB table `faq_suggestions`
- add script `src/scripts/generateFaq.js` to analyze `messages` and save suggestions
- expose new admin routes and view for FAQ suggestions
- add link to FAQ page from organizations list
- update README with usage instructions
- test new admin routes

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68896b694f40833190f2cc30e572c04f