### PR TITLE
Add working hours support

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -165,8 +165,15 @@ app.get('/org/new', requireEditor, (req, res) => {
 });
 
 app.post('/org/new', requireEditor, async (req, res) => {
-  const { name, phone, instructions, language } = req.body;
-  await createOrganization(name, phone, instructions, language);
+  const { name, phone, instructions, language, working_hours_start, working_hours_end } = req.body;
+  await createOrganization(
+    name,
+    phone,
+    instructions,
+    language,
+    working_hours_start || null,
+    working_hours_end || null
+  );
   res.redirect('/');
 });
 
@@ -192,6 +199,29 @@ app.get('/org/:id/upload', requireEditor, (req, res) => {
 app.post('/org/:id/upload', requireEditor, async (req, res) => {
   const { filePath } = req.body;
   await upload(req.params.id, filePath);
+  res.redirect('/');
+});
+
+app.get('/org/:id/hours', requireEditor, async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT name, working_hours_start, working_hours_end FROM organizations WHERE id=$1',
+    [req.params.id]
+  );
+  const org = rows[0] || {};
+  res.render('editHours', {
+    orgId: req.params.id,
+    name: org.name,
+    start: org.working_hours_start || '',
+    end: org.working_hours_end || '',
+  });
+});
+
+app.post('/org/:id/hours', requireEditor, async (req, res) => {
+  const { working_hours_start, working_hours_end } = req.body;
+  await pool.query(
+    'UPDATE organizations SET working_hours_start=$1, working_hours_end=$2 WHERE id=$3',
+    [working_hours_start || null, working_hours_end || null, req.params.id]
+  );
   res.redirect('/');
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,17 @@ const logger = require('./logger');
 /**
  * Create an organization entry in the database.
  */
-async function createOrganization(name, phone, instructions, language = 'ar') {
+async function createOrganization(
+  name,
+  phone,
+  instructions,
+  language = 'ar',
+  workingHoursStart,
+  workingHoursEnd
+) {
   const { rows } = await pool.query(
-    'INSERT INTO organizations (name, phone, instructions, language) VALUES ($1, $2, $3, $4) RETURNING *',
-    [name, phone, instructions, language]
+    'INSERT INTO organizations (name, phone, instructions, language, working_hours_start, working_hours_end) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+    [name, phone, instructions, language, workingHoursStart, workingHoursEnd]
   );
   return rows[0];
 }

--- a/src/initDb.js
+++ b/src/initDb.js
@@ -12,6 +12,8 @@ async function init() {
       assistant_id TEXT,
       vector_store_id TEXT,
       language TEXT DEFAULT 'ar',
+      working_hours_start TIME,
+      working_hours_end TIME,
       created_at TIMESTAMP DEFAULT NOW()
     );
   `);
@@ -27,6 +29,14 @@ async function init() {
 
   await pool.query(
     "ALTER TABLE organizations ADD COLUMN IF NOT EXISTS language TEXT DEFAULT 'ar'"
+  );
+
+  await pool.query(
+    'ALTER TABLE organizations ADD COLUMN IF NOT EXISTS working_hours_start TIME'
+  );
+
+  await pool.query(
+    'ALTER TABLE organizations ADD COLUMN IF NOT EXISTS working_hours_end TIME'
   );
 
   await pool.query(`

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,6 +15,32 @@ const { connectionGauge, messageCounter } = require('./metrics');
 const { startScheduler } = require('./scheduler');
 require('dotenv').config();
 
+function withinWorkingHours(start, end) {
+  if (!start || !end) return true;
+  const now = new Date();
+  const [sh, sm] = String(start).split(':');
+  const [eh, em] = String(end).split(':');
+  const s = new Date(now);
+  s.setHours(Number(sh), Number(sm), 0, 0);
+  const e = new Date(now);
+  e.setHours(Number(eh), Number(em), 0, 0);
+  return now >= s && now <= e;
+}
+
+async function getOrCreateConversation(orgId, phone) {
+  const { rows } = await pool.query(
+    'SELECT id, thread_id FROM conversations WHERE organization_id=$1 AND customer_phone=$2 ORDER BY id DESC LIMIT 1',
+    [orgId, phone]
+  );
+  if (rows[0]) return rows[0];
+  const thread = await openai.beta.threads.create();
+  const insert = await pool.query(
+    'INSERT INTO conversations (organization_id, customer_phone, thread_id) VALUES ($1,$2,$3) RETURNING *',
+    [orgId, phone, thread.id]
+  );
+  return insert.rows[0];
+}
+
 const WEBHOOK_URL = process.env.WEBHOOK_URL;
 
 async function postWebhook(data) {
@@ -102,6 +128,38 @@ const worker = new Worker(
       return;
     }
     try {
+      const { rows: orgRows } = await pool.query(
+        'SELECT working_hours_start, working_hours_end, instructions FROM organizations WHERE id=$1',
+        [orgId]
+      );
+      const org = orgRows[0] || {};
+      if (!withinWorkingHours(org.working_hours_start, org.working_hours_end)) {
+        const conv = await getOrCreateConversation(orgId, sender);
+        await pool.query(
+          'INSERT INTO messages (conversation_id, sender, text, attachment_type, attachment_path) VALUES ($1,$2,$3,$4,$5)',
+          [conv.id, 'user', text, attachmentType, attachmentPath]
+        );
+        await postWebhook({
+          sender,
+          text,
+          timestamp: job.data.receivedAt || Date.now(),
+        });
+        const reply = org.instructions || 'سنعود خلال ساعات العمل';
+        await pool.query(
+          'INSERT INTO messages (conversation_id, sender, text) VALUES ($1,$2,$3)',
+          [conv.id, 'assistant', reply]
+        );
+        await postWebhook({ sender: 'assistant', text: reply, timestamp: Date.now() });
+        const latency = Date.now() - (job.data.receivedAt || Date.now());
+        await pool.query(
+          'INSERT INTO conversation_stats (conversation_id, response_time_ms) VALUES ($1,$2)',
+          [conv.id, latency]
+        );
+        messageCounter.labels(String(orgId), 'sent').inc();
+        await sock.sendMessage(sender, { text: reply });
+        return;
+      }
+
       const reply = await sendMessage(orgId, assistantId, sender, text);
       if (/لا أفهم|غير واضح/.test(reply)) {
         await pool.query(

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -72,7 +72,14 @@ describe('admin routes', () => {
     const agent = request.agent(app);
     await agent.post('/login').send('username=admin&password=secret&token=123456');
     await agent.post('/org/new').send('name=Test&phone=123');
-    expect(createOrganization).toHaveBeenCalledWith('Test', '123', undefined, undefined);
+    expect(createOrganization).toHaveBeenCalledWith(
+      'Test',
+      '123',
+      undefined,
+      undefined,
+      null,
+      null
+    );
   });
 
   it('lists organizations', async () => {

--- a/views/editHours.ejs
+++ b/views/editHours.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Edit Working Hours</title>
+</head>
+<body>
+<h1>Edit Working Hours for <%= name %></h1>
+<form action="/org/<%= orgId %>/hours" method="post">
+  <label>Start: <input type="time" name="working_hours_start" value="<%= start %>"/></label><br/>
+  <label>End: <input type="time" name="working_hours_end" value="<%= end %>"/></label><br/>
+  <button type="submit">Save</button>
+</form>
+</body>
+</html>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -23,6 +23,7 @@
       <button type="submit">Create Assistant</button>
     </form>
     <a href="/org/<%= o.id %>/upload">Upload File</a>
+    <a href="/org/<%= o.id %>/hours">Edit Hours</a>
   </li>
 <% }); %>
 </ul>

--- a/views/newOrg.ejs
+++ b/views/newOrg.ejs
@@ -9,6 +9,8 @@
   <label>Name: <input type="text" name="name"/></label><br/>
   <label>Phone: <input type="text" name="phone"/></label><br/>
   <label>Language: <input type="text" name="language" value="ar"/></label><br/>
+  <label>Working hours start: <input type="time" name="working_hours_start"/></label><br/>
+  <label>Working hours end: <input type="time" name="working_hours_end"/></label><br/>
   <label>Instructions:<br/>
     <textarea name="instructions" rows="5" cols="40"></textarea>
   </label><br/>


### PR DESCRIPTION
## Summary
- support working hours columns in DB
- allow setting working hours when creating or editing orgs
- respond with default text during off-hours
- test admin route with updated args

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897145f3488331943f9849865ff97a