### PR TITLE
Fix cross-platform path usage in worker tests

### DIFF
--- a/tests/workerFlow.test.js
+++ b/tests/workerFlow.test.js
@@ -1,4 +1,5 @@
 let handlers;
+const path = require('path');
 const mockSock = { ev: { on: jest.fn() }, sendMessage: jest.fn() };
 
 jest.mock('bullmq', () => {
@@ -74,8 +75,9 @@ describe('worker message flow', () => {
         replyAttachmentPath: 'uploads/pic.jpg',
       },
     });
+    const attachmentPath = path.join('uploads', 'pic.jpg');
     expect(mockSock.sendMessage).toHaveBeenCalledWith('123', {
-      image: { url: expect.stringContaining('uploads/pic.jpg') },
+      image: { url: expect.stringContaining(attachmentPath) },
       caption: 'file',
     });
   });


### PR DESCRIPTION
## Summary
- import `path` in `workerFlow` tests
- generate attachment path using `path.join`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688975eb2cd483318882d417ec8db17c