### PR TITLE
Validate OpenAI key format

### DIFF
--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1516,3 +1516,78 @@ No code suggestions found for the PR.
 
 ---
 
+
+
+---
+
+## 🧠 PR Comments (PR #1)
+**Title**: Validate OpenAI key format
+
+**Branch**: `codex/update-key-validation-in-openai.js` &nbsp;&nbsp; 📅 **Date**: 2025-07-30
+
+### 💬 Comment 1 by `qodo-merge-pro[bot]`
+
+## PR Reviewer Guide 🔍
+
+Here are some key observations to aid the review process:
+
+<table>
+<tr><td>⏱️&nbsp;<strong>Estimated effort to review</strong>: 2 🔵🔵⚪⚪⚪</td></tr>
+<tr><td>🧪&nbsp;<strong>PR contains tests</strong></td></tr>
+<tr><td>🔒&nbsp;<strong>No security concerns identified</strong></td></tr>
+<tr><td>⚡&nbsp;<strong>Recommended focus areas for review</strong><br><br>
+
+<details><summary><a href='https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1/files#diff-0988a07dae73d97c2885e82effe13ef6fd92dfd04f55c446a4c3ca7324db75e6R20-R20'><strong>Logic Fix</strong></a>
+
+The validation logic change from AND to OR condition fixes a critical bug where valid keys starting with 'sk-' but shorter than 40 characters would incorrectly pass validation. Verify this change correctly rejects all invalid key formats.
+</summary>
+
+```javascript
+if (!key || !key.startsWith('sk-') || key.length < 40) {
+  logger.error('OPENAI_API_KEY is missing or invalid');
+```
+
+</details>
+
+<details><summary><a href='https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1/files#diff-7f348516a9758eca58203fced3ff8c1c4b8bf4a7a9e6a76d24e1f6d5fe8228c1R275-R288'><strong>Test Coverage</strong></a>
+
+The new test case validates invalid key format handling but uses a generic 'invalid-key' string. Consider testing edge cases like keys that start with 'sk-' but are too short, or keys with correct length but wrong prefix.
+</summary>
+
+```javascript
+it('exits if OPENAI_API_KEY is invalid', () => {
+  jest.resetModules();
+  const logger = require('../src/logger');
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('exit');
+  });
+  process.env.OPENAI_API_KEY = 'invalid-key';
+  logger.error.mockClear();
+  expect(() => require('../src/openai')).toThrow('exit');
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(logger.error).toHaveBeenCalled();
+  exitSpy.mockRestore();
+  process.env.OPENAI_API_KEY = 'sk-test-valid-key';
+});
+```
+
+</details>
+
+</td></tr>
+</table>
+
+
+🔗 [View in GitHub](https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1#issuecomment-3135528306)
+
+---
+
+### 💬 Comment 2 by `qodo-merge-pro[bot]`
+
+## PR Code Suggestions ✨
+
+No code suggestions found for the PR.
+
+🔗 [View in GitHub](https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1#issuecomment-3135529465)
+
+---
+

--- a/src/openai.js
+++ b/src/openai.js
@@ -17,7 +17,7 @@ const logger = require('./logger');
 dotenv.config();
 
 const key = process.env.OPENAI_API_KEY;
-if (!key || (key.startsWith('sk-') && key.length < 40)) {
+if (!key || !key.startsWith('sk-') || key.length < 40) {
   logger.error('OPENAI_API_KEY is missing or invalid');
   process.exit(1);
 }

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -271,4 +271,19 @@ describe('admin routes', () => {
     exitSpy.mockRestore();
     process.env.OPENAI_API_KEY = 'sk-test-valid-key';
   });
+
+  it('exits if OPENAI_API_KEY is invalid', () => {
+    jest.resetModules();
+    const logger = require('../src/logger');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    process.env.OPENAI_API_KEY = 'invalid-key';
+    logger.error.mockClear();
+    expect(() => require('../src/openai')).toThrow('exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(logger.error).toHaveBeenCalled();
+    exitSpy.mockRestore();
+    process.env.OPENAI_API_KEY = 'sk-test-valid-key';
+  });
 });


### PR DESCRIPTION
### **User description**
## Summary
- validate `OPENAI_API_KEY` format at startup
- test invalid OpenAI key handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889e59f3a1c8331a13e361ad187cd2d


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix OpenAI API key validation logic bug

- Add test for invalid key format handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid Key Check"] --> B["Fixed Logic"] --> C["Process Exit"]
  D["New Test"] --> E["Invalid Key Scenario"] --> F["Validation Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openai.js</strong><dd><code>Fix API key validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openai.js

<ul><li>Fixed validation logic from AND to OR condition<br> <li> Now properly rejects keys that don't start with 'sk-'<br> <li> Maintains minimum length requirement of 40 characters</ul>


</details>


  </td>
  <td><a href="https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1/files#diff-0988a07dae73d97c2885e82effe13ef6fd92dfd04f55c446a4c3ca7324db75e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>admin.test.js</strong><dd><code>Add invalid key format test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/admin.test.js

<ul><li>Added test case for invalid OpenAI API key format<br> <li> Tests process exit behavior with non-'sk-' prefixed keys<br> <li> Ensures error logging occurs on validation failure</ul>


</details>


  </td>
  <td><a href="https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/1/files#diff-7f348516a9758eca58203fced3ff8c1c4b8bf4a7a9e6a76d24e1f6d5fe8228c1">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

