### PR TITLE
Fix upload error message fallback

### DIFF
--- a/views/upload.ejs
+++ b/views/upload.ejs
@@ -36,12 +36,14 @@ document.getElementById('uploadForm').addEventListener('submit', async (e) => {
     });
     if (!res.ok) {
       const text = await res.text();
-      let message = text;
+      let message = 'Upload failed';
       try {
         const data = JSON.parse(text);
         message = data.message || message;
-      } catch {}
-      throw new Error(message || 'Upload failed');
+      } catch {
+        if (text) message = text;
+      }
+      throw new Error(message);
     }
     let result;
     const type = res.headers.get('content-type') || '';


### PR DESCRIPTION
### **User description**
## Summary
- improve fallback logic for upload error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a57198c18833185fc79dfe591d860


___

### **PR Type**
Bug fix


___

### **Description**
- Improve error message fallback logic in upload form

- Set default error message before parsing response

- Handle empty response text gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upload Error"] --> B["Set Default Message"]
  B --> C["Try Parse JSON"]
  C --> D["Use JSON Message"] 
  C --> E["Use Text Response"]
  E --> F["Final Error Message"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upload.ejs</strong><dd><code>Improve upload error message handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/upload.ejs

<ul><li>Set default error message 'Upload failed' before parsing<br> <li> Add fallback to use response text when JSON parsing fails<br> <li> Remove redundant fallback check in throw statement</ul>


</details>


  </td>
  <td><a href="https://github.com/AbdulwahabMohammed/whatsapp-bot/pull/9/files#diff-b69ac8622add25c4bf680301d8606e434250432069f023049004a6c3a68b22d5">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

