### PR TITLE
feat: support organization-specific bots

### DIFF
--- a/src/assistant.js
+++ b/src/assistant.js
@@ -8,17 +8,16 @@ const logger = require('./logger');
  * Create an assistant for an organization.
  */
 async function createAssistant (organizationId) {
-  const orgRes = await pool.query(
-    'SELECT assistant_id, instructions FROM organizations WHERE id=$1',
-    [organizationId]
-  );
-  const org = orgRes.rows[0];
+  const orgRes = await pool.query('SELECT instructions FROM organizations WHERE id=$1', [organizationId]);
+  const botRes = await pool.query('SELECT * FROM bots WHERE organization_id=$1', [organizationId]);
+  const org = orgRes.rows[0] || {};
+  const bot = botRes.rows[0];
   const instructions =
-    org?.instructions ||
+    org.instructions ||
     'رد فقط باستخدام البيانات المقدمة من الملفات المرجعية الخاصة بالمنشأة.';
 
-  if (org?.assistant_id) {
-    const assistant = await openai.beta.assistants.update(org.assistant_id, {
+  if (bot?.assistant_id) {
+    const assistant = await openai.beta.assistants.update(bot.assistant_id, {
       instructions
     });
     logger.info(`Assistant updated: ${assistant.id}`);
@@ -34,7 +33,17 @@ async function createAssistant (organizationId) {
     model: 'gpt-4o'
   });
 
-  await pool.query('UPDATE organizations SET assistant_id=$1 WHERE id=$2', [assistant.id, organizationId]);
+  if (bot) {
+    await pool.query(
+      'UPDATE bots SET assistant_id=$1, name=$2, status=$3 WHERE id=$4',
+      [assistant.id, `Org-${organizationId}-Bot`, 'active', bot.id]
+    );
+  } else {
+    await pool.query(
+      'INSERT INTO bots (organization_id, assistant_id, name, status) VALUES ($1,$2,$3,$4)',
+      [organizationId, assistant.id, `Org-${organizationId}-Bot`, 'active']
+    );
+  }
 
   logger.info(`Assistant created: ${assistant.id}`);
   return assistant;
@@ -44,7 +53,13 @@ async function createAssistant (organizationId) {
  * Upload a file and attach it to the organization assistant.
  */
 async function uploadFile (organizationId, filePath) {
-  const orgRes = await pool.query('SELECT assistant_id, vector_store_id FROM organizations WHERE id=$1', [organizationId]);
+  const orgRes = await pool.query(
+    `SELECT b.assistant_id, o.vector_store_id
+     FROM organizations o
+     JOIN bots b ON b.organization_id = o.id
+     WHERE o.id=$1`,
+    [organizationId]
+  );
   const org = orgRes.rows[0];
   if (!org) {
     throw new Error('Organization not found');

--- a/src/initDb.js
+++ b/src/initDb.js
@@ -9,7 +9,6 @@ async function init () {
       name TEXT NOT NULL,
       phone TEXT,
       instructions TEXT,
-      assistant_id TEXT,
       vector_store_id TEXT,
       language TEXT DEFAULT 'ar',
       working_hours_start TIME,
@@ -142,11 +141,34 @@ async function init () {
   `);
 
   await pool.query(`
+    CREATE TABLE IF NOT EXISTS bots (
+      id SERIAL PRIMARY KEY,
+      organization_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
+      assistant_id TEXT,
+      name TEXT,
+      phone TEXT,
+      status TEXT,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(
+    'CREATE INDEX IF NOT EXISTS idx_bots_organization_id ON bots(organization_id)'
+  );
+  await pool.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_assistant_id ON bots(assistant_id)'
+  );
+  await pool.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_phone ON bots(phone)'
+  );
+
+  await pool.query(`
     CREATE TABLE IF NOT EXISTS users (
       id SERIAL PRIMARY KEY,
       username TEXT UNIQUE NOT NULL,
       password_hash TEXT NOT NULL,
       role TEXT NOT NULL DEFAULT 'admin',
+      organization_id INTEGER REFERENCES organizations(id),
       totp_secret TEXT
     );
   `);
@@ -160,11 +182,19 @@ async function init () {
   );
 
   await pool.query(
+    'ALTER TABLE users ADD COLUMN IF NOT EXISTS organization_id INTEGER REFERENCES organizations(id)'
+  );
+
+  await pool.query(
     'CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)'
   );
 
   await pool.query(
     'CREATE INDEX IF NOT EXISTS idx_conversations_customer_phone ON conversations(customer_phone)'
+  );
+
+  await pool.query(
+    'CREATE INDEX IF NOT EXISTS idx_users_organization_id ON users(organization_id)'
   );
 
   if (process.env.ADMIN_PASSWORD) {

--- a/src/scripts/migrateBots.js
+++ b/src/scripts/migrateBots.js
@@ -1,0 +1,50 @@
+const pool = require('../db');
+const logger = require('../logger');
+
+async function migrate () {
+  await pool.query(
+    'ALTER TABLE users ADD COLUMN IF NOT EXISTS organization_id INTEGER REFERENCES organizations(id)'
+  );
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS bots (
+      id SERIAL PRIMARY KEY,
+      organization_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
+      assistant_id TEXT,
+      name TEXT,
+      phone TEXT,
+      status TEXT,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+
+  await pool.query(
+    'CREATE INDEX IF NOT EXISTS idx_bots_organization_id ON bots(organization_id)'
+  );
+  await pool.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_assistant_id ON bots(assistant_id)'
+  );
+  await pool.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_phone ON bots(phone)'
+  );
+
+  await pool.query(`
+    INSERT INTO bots (organization_id, assistant_id, name, phone, status)
+    SELECT id, assistant_id, name, phone, 'active'
+    FROM organizations
+    WHERE assistant_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM bots b WHERE b.organization_id = organizations.id
+      )
+  `);
+
+  await pool.query('ALTER TABLE organizations DROP COLUMN IF EXISTS assistant_id');
+
+  logger.info('Migration completed');
+  process.exit();
+}
+
+migrate().catch(err => {
+  logger.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/src/scripts/uploadFile.js
+++ b/src/scripts/uploadFile.js
@@ -9,7 +9,13 @@ async function upload (orgId, filePath) {
     throw new Error('Usage: node src/scripts/uploadFile.js <organizationId> <filePath>');
   }
 
-  const orgRes = await pool.query('SELECT assistant_id, vector_store_id FROM organizations WHERE id=$1', [orgId]);
+  const orgRes = await pool.query(
+    `SELECT b.assistant_id, o.vector_store_id
+     FROM organizations o
+     JOIN bots b ON b.organization_id = o.id
+     WHERE o.id=$1`,
+    [orgId]
+  );
   const org = orgRes.rows[0];
   if (!org) {
     throw new Error('Organization not found');

--- a/src/whatsappBot.js
+++ b/src/whatsappBot.js
@@ -122,7 +122,12 @@ async function startForOrg (org, attempt = 0) {
 }
 
 async function start () {
-  const { rows } = await pool.query('SELECT * FROM organizations WHERE assistant_id IS NOT NULL');
+  const { rows } = await pool.query(
+    `SELECT o.id, b.assistant_id
+     FROM organizations o
+     JOIN bots b ON b.organization_id = o.id
+     WHERE b.assistant_id IS NOT NULL AND (b.status IS NULL OR b.status = 'active')`
+  );
   if (rows.length === 0) {
     throw new Error('No organizations with assistants found');
   }

--- a/src/worker.js
+++ b/src/worker.js
@@ -331,7 +331,12 @@ const bulkWorker = new Worker(
 );
 
 async function start () {
-  const { rows } = await pool.query('SELECT * FROM organizations WHERE assistant_id IS NOT NULL');
+  const { rows } = await pool.query(
+    `SELECT o.id, b.assistant_id
+     FROM organizations o
+     JOIN bots b ON b.organization_id = o.id
+     WHERE b.assistant_id IS NOT NULL AND (b.status IS NULL OR b.status = 'active')`
+  );
   if (rows.length === 0) {
     throw new Error('No organizations with assistants found');
   }


### PR DESCRIPTION
## Summary
- add `bots` table and link `users` with optional `organization_id`
- provide migration script to backfill bots and drop legacy `assistant_id`
- update assistant workflow and workers to use bots table

## Testing
- `npm test`
- `node src/initDb.js` *(fails: ECONNREFUSED)*
- `node src/scripts/migrateBots.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_689182eb826c8331bb6203e49a594cd9