### PR TITLE
feat: add bot management api and tests

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -20,7 +20,12 @@ const PDFDocument = require('pdfkit');
 const speakeasy = require('speakeasy');
 const qrcode = require('qrcode');
 const expressLayouts = require('express-ejs-layouts');
-const { events: botEvents } = require('./botManager');
+const {
+  startBot,
+  stopBot,
+  getBotStatus,
+  events: botEvents
+} = require('./botManager');
 
 const app = express();
 expressWs(app);
@@ -64,11 +69,31 @@ function requireEditor (req, res, next) {
 function requireOrgAccess (req, res, next) {
   if (req.session.role === 'admin') return next();
   const orgId = req.session.organization_id;
-  const target = req.params.id || req.body.organization_id || req.query.organization_id;
+  const target =
+    req.params.id ||
+    req.params.orgId ||
+    req.body.organization_id ||
+    req.query.organization_id;
   if (target && Number(target) !== Number(orgId)) {
     return res.status(403).send('Forbidden');
   }
   next();
+}
+
+async function requireBotAccess (req, res, next) {
+  if (req.session.role === 'admin') return next();
+  try {
+    const { rows } = await pool.query('SELECT organization_id FROM bots WHERE id=$1', [
+      req.params.botId
+    ]);
+    const orgId = rows[0]?.organization_id;
+    if (!orgId || Number(orgId) !== Number(req.session.organization_id)) {
+      return res.status(403).send('Forbidden');
+    }
+    next();
+  } catch (e) {
+    next(e);
+  }
 }
 
 function requireLogin (req, res, next) {
@@ -112,7 +137,12 @@ async function broadcastStatus () {
   values.forEach(v => {
     conn[v.labels.bot_id] = v.value;
   });
-  const data = JSON.stringify({ queue, connections: conn });
+  const { rows } = await pool.query('SELECT id FROM bots');
+  const statuses = {};
+  rows.forEach(r => {
+    statuses[r.id] = getBotStatus(r.id);
+  });
+  const data = JSON.stringify({ queue, connections: conn, statuses });
   wsClients.forEach(client => {
     try { client.send(data); } catch (e) {}
   });
@@ -325,6 +355,40 @@ app.post('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => 
     [working_hours_start || null, working_hours_end || null, req.params.id]
   );
   res.redirect('/');
+});
+
+app.get('/org/:orgId/bots', requireEditor, requireOrgAccess, async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT id, name, assistant_id, status FROM bots WHERE organization_id=$1',
+    [req.params.orgId]
+  );
+  res.json(rows);
+});
+
+app.post('/org/:orgId/bots', requireEditor, requireOrgAccess, async (req, res) => {
+  const { assistant_id, name, phone } = req.body;
+  const { rows } = await pool.query(
+    'INSERT INTO bots (organization_id, assistant_id, name, phone, status) VALUES ($1,$2,$3,$4,$5) RETURNING *',
+    [req.params.orgId, assistant_id, name || null, phone || null, 'stopped']
+  );
+  res.json(rows[0]);
+});
+
+app.post('/bot/:botId/start', requireEditor, requireBotAccess, async (req, res) => {
+  const { rows } = await pool.query('SELECT * FROM bots WHERE id=$1', [req.params.botId]);
+  const bot = rows[0];
+  if (!bot) return res.status(404).send('Not found');
+  await startBot(bot);
+  res.json({ status: getBotStatus(bot.id) });
+});
+
+app.post('/bot/:botId/stop', requireEditor, requireBotAccess, async (req, res) => {
+  stopBot(req.params.botId);
+  res.json({ status: 'stopped' });
+});
+
+app.get('/bot/:botId/status', requireEditor, requireBotAccess, async (req, res) => {
+  res.json({ status: getBotStatus(req.params.botId) });
 });
 
 app.get('/users', requireAdmin, async (req, res) => {

--- a/tests/botApi.test.js
+++ b/tests/botApi.test.js
@@ -1,0 +1,153 @@
+const request = require('supertest');
+const WebSocket = require('ws');
+const EventEmitter = require('events');
+const bcrypt = require('bcrypt');
+
+process.env.SESSION_SECRET = 'test-secret';
+process.env.ADMIN_PORT = 0;
+
+jest.mock('../src/logger', () => ({ info: jest.fn(), error: jest.fn() }));
+
+jest.mock('../src/metrics', () => ({
+  client: { register: { contentType: 'text/plain', metrics: jest.fn(async () => '') } },
+  requestCounter: { inc: jest.fn() },
+  connectionGauge: { get: jest.fn(() => ({ values: [] })), labels: () => ({ set: jest.fn() }) },
+  queueLengthGauge: { set: jest.fn() }
+}));
+
+jest.mock('../src/queue', () => ({
+  messageQueue: { close: jest.fn(async () => {}) },
+  bulkQueue: { add: jest.fn() },
+  getQueueLength: jest.fn(async () => 0)
+}));
+
+jest.mock('speakeasy', () => ({
+  totp: { verify: jest.fn(() => true) },
+  generateSecret: jest.fn()
+}));
+
+jest.mock('qrcode', () => ({ toDataURL: jest.fn() }));
+jest.mock('../src/assistant', () => ({ createAssistant: jest.fn() }));
+jest.mock('../src/scripts/uploadFile', () => ({ upload: jest.fn() }));
+
+const mockEvents = new EventEmitter();
+let mockStatus = 'stopped';
+jest.mock('../src/botManager', () => ({
+  startBot: jest.fn(async () => { mockStatus = 'started'; }),
+  stopBot: jest.fn(() => { mockStatus = 'stopped'; }),
+  getBotStatus: jest.fn(() => mockStatus),
+  events: mockEvents
+}));
+
+const mockHash = bcrypt.hashSync('secret', 10);
+const bots = [];
+jest.mock('../src/db', () => ({
+  query: jest.fn(async (text, params) => {
+    if (text.includes('SELECT password_hash')) {
+      return {
+        rows: [
+          {
+            password_hash: mockHash,
+            role: 'editor',
+            totp_secret: 'AAAA',
+            organization_id: 1
+          }
+        ]
+      };
+    }
+    if (text.startsWith('INSERT INTO bots')) {
+      const bot = {
+        id: bots.length + 1,
+        organization_id: Number(params[0]),
+        assistant_id: params[1],
+        name: params[2],
+        phone: params[3],
+        status: params[4]
+      };
+      bots.push(bot);
+      return { rows: [bot] };
+    }
+    if (text.startsWith('SELECT id, name, assistant_id, status FROM bots WHERE organization_id=$1')) {
+      return { rows: bots.filter(b => b.organization_id === Number(params[0])) };
+    }
+    if (text.startsWith('SELECT organization_id FROM bots WHERE id=$1')) {
+      const bot = bots.find(b => b.id === Number(params[0]));
+      return { rows: bot ? [{ organization_id: bot.organization_id }] : [] };
+    }
+    if (text.startsWith('SELECT * FROM bots WHERE id=$1')) {
+      const bot = bots.find(b => b.id === Number(params[0]));
+      return { rows: bot ? [bot] : [] };
+    }
+    if (text.startsWith('SELECT id FROM bots')) {
+      return { rows: bots.map(b => ({ id: b.id })) };
+    }
+    return { rows: [] };
+  })
+}));
+
+const { app, startAdminServer, stopAdminServer } = require('../src/admin');
+
+let serverInfo;
+beforeAll(() => {
+  serverInfo = startAdminServer();
+});
+
+afterAll(async () => {
+  await stopAdminServer(serverInfo.server, serverInfo.intervalId);
+});
+
+beforeEach(() => {
+  mockStatus = 'stopped';
+});
+
+async function login(agent) {
+  await agent.post('/login').send('username=ed&password=secret&token=123456');
+}
+
+describe('bot API', () => {
+  test('creates bot linked to organization', async () => {
+    const agent = request.agent(app);
+    await login(agent);
+    const res = await agent
+      .post('/org/1/bots')
+      .send('assistant_id=a1&name=Bot1');
+    expect(res.status).toBe(200);
+    expect(res.body.assistant_id).toBe('a1');
+    const list = await agent.get('/org/1/bots');
+    expect(list.body.length).toBe(1);
+    expect(list.body[0].assistant_id).toBe('a1');
+  });
+
+  test('start and stop bot via API', async () => {
+    const agent = request.agent(app);
+    await login(agent);
+    await agent.post('/org/1/bots').send('assistant_id=a1');
+    let res = await agent.post('/bot/1/start');
+    expect(res.body.status).toBe('started');
+    res = await agent.get('/bot/1/status');
+    expect(res.body.status).toBe('started');
+    res = await agent.post('/bot/1/stop');
+    expect(res.body.status).toBe('stopped');
+  });
+
+  test('broadcasts qr over websocket', async () => {
+    const agent = request.agent(app);
+    await login(agent);
+    await agent.post('/org/1/bots').send('assistant_id=a1');
+    const port = serverInfo.server.address().port;
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    await new Promise(resolve => ws.on('open', resolve));
+    const msgPromise = new Promise(resolve => {
+      ws.on('message', data => {
+        const obj = JSON.parse(data.toString());
+        if (obj.qr) resolve(obj);
+      });
+    });
+    await agent.post('/bot/1/start');
+    mockEvents.emit('update', { botId: 1, status: 'qr', qr: '123' });
+    const msg = await msgPromise;
+    expect(msg).toEqual({ botId: 1, status: 'qr', qr: '123' });
+    ws.close();
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose REST API and WebSocket updates to manage bots per organization
- broadcast bot status including new bots
- add tests for bot creation, lifecycle control, and QR websocket events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918e727a5883318028d1cf3477c0c6