### PR TITLE
Fix worker reconnection handling

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -7,6 +7,108 @@ const openai = require('./openai');
 const { messageCounter } = require('./metrics');
 const { startScheduler } = require('./scheduler');
 const { getSocket, startBot } = require('./botManager');
+const { messageQueue, bulkQueue } = require('./queue');
+
+const MIN_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 60000;
+const DEFAULT_RETRY_DELAY_MS = 5000;
+const CONNECTION_RETRY_DELAY_MS = Math.min(
+  MAX_RETRY_DELAY_MS,
+  Math.max(
+    MIN_RETRY_DELAY_MS,
+    parseInt(process.env.CONNECTION_RETRY_DELAY || DEFAULT_RETRY_DELAY_MS, 10) || DEFAULT_RETRY_DELAY_MS
+  )
+);
+
+function isSocketOpen (sock) {
+  return Boolean(sock?.ws?.readyState === 'open');
+}
+
+async function ensureSocketOpen (botId) {
+  let sock = getSocket(botId);
+  if (isSocketOpen(sock)) {
+    return { sock, retriable: true };
+  }
+
+  let botRow;
+  try {
+    const { rows } = await pool.query('SELECT * FROM bots WHERE id=$1', [botId]);
+    botRow = rows[0];
+  } catch (err) {
+    logger.error(`Failed to load bot ${botId} for reconnection:`, err);
+    return { sock: null, retriable: true };
+  }
+
+  if (!botRow) {
+    logger.error(`Bot ${botId} not found while trying to establish a WhatsApp connection.`);
+    return { sock: null, retriable: false };
+  }
+
+  try {
+    await startBot(botRow);
+  } catch (err) {
+    logger.error(`Failed to start bot ${botId}:`, err);
+    return { sock: null, retriable: true };
+  }
+
+  sock = getSocket(botId);
+  if (isSocketOpen(sock)) {
+    return { sock, retriable: true };
+  }
+
+  return { sock: null, retriable: true };
+}
+
+async function rescheduleJob (job, queue, defaultJobName, reason, overrideData) {
+  const jobName = job.name || defaultJobName;
+  const delay = CONNECTION_RETRY_DELAY_MS;
+  const data = overrideData ?? job.data;
+  const contextId = job.id || jobName;
+  logger.warn(
+    `Rescheduling job ${contextId} due to WhatsApp connection issue: ${reason}. Retrying in ${delay}ms.`
+  );
+
+  if (typeof job.retry === 'function') {
+    try {
+      await job.retry();
+      return;
+    } catch (err) {
+      logger.warn('job.retry failed, falling back to queue requeue:', err);
+    }
+  }
+
+  try {
+    await queue.add(jobName, data, { delay });
+  } catch (err) {
+    logger.error('Failed to enqueue job retry:', err);
+    throw err;
+  }
+}
+
+async function ensureReadySocketOrReschedule (
+  job,
+  botId,
+  queue,
+  defaultJobName,
+  currentSock,
+  overrideData
+) {
+  if (isSocketOpen(currentSock)) {
+    return currentSock;
+  }
+
+  const { sock, retriable } = await ensureSocketOpen(botId);
+  if (sock) {
+    return sock;
+  }
+
+  if (retriable) {
+    const state = getSocket(botId)?.ws?.readyState ?? 'unavailable';
+    await rescheduleJob(job, queue, defaultJobName, `state ${state}`, overrideData);
+  }
+
+  return null;
+}
 
 function withinWorkingHours (start, end) {
   if (!start || !end) return true;
@@ -73,17 +175,15 @@ const worker = new Worker(
     } = job.data;
     const messageText = text || '';
 
-    let sock = getSocket(botId);
+    const socketResult = await ensureSocketOpen(botId);
+    let sock = socketResult.sock;
     if (!sock) {
-      // try to start the bot if not running
-      const { rows } = await pool.query('SELECT * FROM bots WHERE id=$1', [botId]);
-      if (rows[0]) {
-        await startBot(rows[0]);
-        sock = getSocket(botId);
+      if (socketResult.retriable) {
+        const state = getSocket(botId)?.ws?.readyState ?? 'unavailable';
+        await rescheduleJob(job, messageQueue, job.name || 'message', `state ${state}`);
+      } else {
+        logger.error(`Unable to start WhatsApp bot ${botId}; dropping job ${job.id || 'messages'}.`);
       }
-    }
-    if (!sock) {
-      logger.error(`No WhatsApp connection for bot ${botId}`);
       return;
     }
 
@@ -129,6 +229,15 @@ const worker = new Worker(
           [conv.id, latency]
         );
         messageCounter.labels(String(botId), 'sent').inc();
+        sock = await ensureReadySocketOrReschedule(
+          job,
+          botId,
+          messageQueue,
+          job.name || 'message',
+          sock,
+          undefined
+        );
+        if (!sock) return;
         await sock.sendMessage(sender, { text: reply });
         return;
       }
@@ -222,14 +331,33 @@ const worker = new Worker(
           };
         }
       }
+      sock = await ensureReadySocketOrReschedule(
+        job,
+        botId,
+        messageQueue,
+        job.name || 'message',
+        sock,
+        undefined
+      );
+      if (!sock) return;
       await sock.sendMessage(sender, content);
     } catch (err) {
       if (err && (err.status === 429 || err.code === 'insufficient_quota')) {
         logger.warn('OpenAI quota exceeded or rate limited:', err);
         try {
-          await sock.sendMessage(sender, {
-            text: 'Service temporarily unavailable. Please try again later.'
-          });
+          sock = await ensureReadySocketOrReschedule(
+            job,
+            botId,
+            messageQueue,
+            job.name || 'message',
+            sock,
+            undefined
+          );
+          if (sock) {
+            await sock.sendMessage(sender, {
+              text: 'Service temporarily unavailable. Please try again later.'
+            });
+          }
         } catch (notifyErr) {
           logger.error('Failed to notify user about service outage:', notifyErr);
         }
@@ -248,13 +376,31 @@ const bulkWorker = new Worker(
   async job => {
     const { botId, orgId, phones, text } = job.data;
     const bulkText = text || '';
-    const sock = getSocket(botId);
+    const socketResult = await ensureSocketOpen(botId);
+    let sock = socketResult.sock;
     if (!sock) {
-      logger.error(`No WhatsApp connection for bot ${botId}`);
+      if (socketResult.retriable) {
+        const state = getSocket(botId)?.ws?.readyState ?? 'unavailable';
+        await rescheduleJob(job, bulkQueue, job.name || 'broadcast', `state ${state}`);
+      } else {
+        logger.error(
+          `Unable to start WhatsApp bot ${botId} for bulk job ${job.id || 'bulkMessages'}.`
+        );
+      }
       return;
     }
-    for (const phone of phones) {
+    for (let index = 0; index < phones.length; index++) {
+      const phone = phones[index];
       try {
+        sock = await ensureReadySocketOrReschedule(
+          job,
+          botId,
+          bulkQueue,
+          job.name || 'broadcast',
+          sock,
+          { ...job.data, phones: phones.slice(index) }
+        );
+        if (!sock) return;
         const { rows } = await pool.query(
           'SELECT id FROM conversations WHERE organization_id=$1 AND customer_phone=$2 ORDER BY id DESC LIMIT 1',
           [orgId, phone]

--- a/tests/workerFlow.test.js
+++ b/tests/workerFlow.test.js
@@ -1,6 +1,6 @@
 let handlers;
 const path = require('path');
-const mockSock = { sendMessage: jest.fn() };
+const mockSock = { sendMessage: jest.fn(), ws: { readyState: 'open' } };
 
 jest.mock('bullmq', () => {
   const __handlers = {};
@@ -14,6 +14,12 @@ jest.mock('bullmq', () => {
 jest.mock('../src/botManager', () => ({
   getSocket: jest.fn(() => mockSock),
   startBot: jest.fn()
+}));
+
+jest.mock('../src/queue', () => ({
+  messageQueue: { add: jest.fn(), getWaitingCount: jest.fn() },
+  bulkQueue: { add: jest.fn() },
+  getQueueLength: jest.fn()
 }));
 
 jest.mock('../src/db', () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }));
@@ -41,6 +47,9 @@ describe('worker message flow', () => {
     const db = require('../src/db');
     db.query.mockReset();
     db.query.mockImplementation(async text => {
+      if (text.startsWith('SELECT * FROM bots WHERE id=$1')) {
+        return { rows: [{ id: 1, organization_id: 1, assistant_id: 'a1' }] };
+      }
       if (text.startsWith('SELECT working_hours_start')) {
         return { rows: [{ working_hours_start: null, working_hours_end: null, instructions: null }] };
       }
@@ -62,9 +71,15 @@ describe('worker message flow', () => {
       return { rows: [] };
     });
     mockSock.sendMessage.mockReset();
+    mockSock.ws.readyState = 'open';
     require('../src/chat').sendMessage.mockReset();
     global.fetch = jest.fn(() => Promise.resolve({}));
     process.env.WEBHOOK_URL = '';
+    const queue = require('../src/queue');
+    queue.messageQueue.add.mockReset();
+    queue.messageQueue.add.mockResolvedValue({});
+    queue.bulkQueue.add.mockReset();
+    queue.bulkQueue.add.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -79,6 +94,31 @@ describe('worker message flow', () => {
     await handlers.messages({ data: { botId: 1, orgId: 1, assistantId: 'a1', sender: '123', text: 'hi' } });
     expect(require('../src/chat').sendMessage).toHaveBeenCalledWith(1, 'a1', '123', 'hi');
     expect(mockSock.sendMessage).toHaveBeenCalledWith('123', { text: 'reply' });
+  });
+
+  test('requeues job when socket is disconnected', async () => {
+    const chat = require('../src/chat');
+    const queue = require('../src/queue');
+    const botManager = require('../src/botManager');
+    chat.sendMessage.mockResolvedValue('reply');
+    mockSock.ws.readyState = 'closed';
+    require('../src/worker');
+    await new Promise(resolve => setImmediate(resolve));
+    const job = {
+      id: '1',
+      name: 'message',
+      data: { botId: 1, orgId: 1, assistantId: 'a1', sender: '123', text: 'hi' }
+    };
+    await handlers.messages(job);
+    expect(botManager.startBot).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, organization_id: 1, assistant_id: 'a1' })
+    );
+    expect(queue.messageQueue.add).toHaveBeenCalledWith(
+      'message',
+      job.data,
+      expect.objectContaining({ delay: expect.any(Number) })
+    );
+    expect(mockSock.sendMessage).not.toHaveBeenCalled();
   });
 
   test('saves image message without caption', async () => {


### PR DESCRIPTION
## Summary
- ensure WhatsApp socket readiness before calling Baileys APIs
- reschedule message and bulk jobs when the socket is disconnected and trigger reconnection attempts
- add regression test covering connection loss and retry logic

## Testing
- npm test -- --runTestsByPath tests/workerFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8a9d8babc8331bad0de6838d85743