### PR TITLE
docs: add environment readiness report

### DIFF
--- a/docs/internal/env-status.md
+++ b/docs/internal/env-status.md
@@ -1,0 +1,29 @@
+# Local Environment Status — April 2024
+
+## Overview
+- `.env` configured for local development following `README.md` and `docs/setup.md` guidance (OpenAI key placeholder, PostgreSQL/Redis pointing to localhost, admin credentials scoped to dev use, and structured logging parameters enabled).
+- Fast development toggles (`FAST_DEV`, polling intervals, and `DETECT_LANGUAGE`) aligned with `.env.dev.example` recommendations to reduce latency during local testing.
+- Logging retention (`LOG_MAX_FILES`, `LOG_ERROR_MAX_FILES`) and console verbosity (`LOG_CONSOLE_LEVEL`) explicitly defined to simplify troubleshooting without overwhelming disk usage.
+
+## Sensitive Variable Compliance Matrix
+| Variable | Recommended Baseline | Actual Value | Status | Notes |
+| --- | --- | --- | --- | --- |
+| `SESSION_SECRET` | Unique, non-default string (not `secret`/empty) for cookie signing | `local-dev-session-secret-change-me-2024` | ✅ متوافق | Placeholder is long and non-default; rotate before staging/production deployments. |
+| `DAILY_TOKEN_LIMIT` | `0` in fast-dev contexts to bypass throttling during local QA (`README.md` guidance) | `0` | ✅ متوافق | Disables metered quotas locally; reintroduce per-tenant caps before staging. |
+| `FAST_DEV` | `true` during local development to enable reduced polling/backoff | `true` | ✅ متوافق | Inherits fast polling and disabled language detection for rapid iteration. |
+
+## Connectivity Check Results
+- Command: `npm run check-env`
+- Outcome: ❌ فشل — `Unable to connect to PostgreSQL at localhost:5432/whatsapp_bot` (database service not running). 【05e03b†L1-L7】
+- Redis connectivity was not tested because the script halted after the PostgreSQL failure; rerun after database provisioning.
+
+## WhatsApp Session Artifacts
+- Listing command: `ls -d auth-*`
+- Result: لم يتم العثور على مجلدات جلسات `auth-*` في بيئة التطوير الحالية. 【30c0ae†L1-L2】
+- Operational risk: إعادة مصادقة واتساب مطلوبة عند تفعيل البوت للمرة الأولى؛ وثِّق QR onboarding قبل الانتقال للبيئات المشتركة.
+
+## Gaps & Recommended Actions
+1. **PostgreSQL Service Missing** — ابدأ خدمة PostgreSQL محليًا (`docker compose up db` أو مثيل مكافئ) ثم أعد تشغيل `npm run check-env` للتأكد من الاتصال. أضف فحصًا تلقائيًا في README Quickstart لتذكير المطوّرين.
+2. **Redis Service Not Validated** — بعد نجاح الاتصال بقاعدة البيانات، أكد توافر Redis 7+ (يمكن تشغيل الحاوية الرسمية `redis:7-alpine`).
+3. **Session Secret Rotation** — استخدم مدير أسرار أو متغيرات بيئة مشفرة عند الانتقال إلى staging/production؛ امنع مشاركة القيمة الحالية مع بيئات متعددة.
+4. **Token Limit Policy** — قبل الإطلاق، حدّد سقفًا يوميًا لكل منشأة يتماشى مع عقود الخدمة لتجنب استهلاك غير متوقع للتوكنات.


### PR DESCRIPTION
## Goal and problem statement
- Configure the local `.env` according to the onboarding docs and capture the current readiness state of required services.
- Provide visibility into sensitive environment variable alignment and operational gaps before advancing to the next project phase.

## Short architectural solution
- Populated the local `.env` with fast-development friendly settings (FAST_DEV, Redis/PostgreSQL endpoints, logging defaults) derived from the existing onboarding docs.
- Added `docs/internal/env-status.md` summarizing the configuration status, a compliance matrix for `SESSION_SECRET`, `DAILY_TOKEN_LIMIT`, and `FAST_DEV`, and action items covering missing dependencies and secret rotation.

## Screenshots/outputs/metrics
- `npm run check-env` → fails: `Unable to connect to PostgreSQL at localhost:5432/whatsapp_bot` (PostgreSQL container not running).
- `ls -d auth-*` → `no auth session directories found`.

## Performance/security/migration impact
- Documentation-only change; no runtime impact. Highlights follow-up security work (secret rotation, token policy).

## Testing plan and verification
- `npm run check-env` (expected failure due to PostgreSQL being offline; documented for follow-up).

## Risks/alternatives considered
- Risk: relying on placeholders for secrets could leak into shared environments if not rotated—documented mitigation steps.
- Alternative of updating `.env.example` was considered but rejected to avoid altering default onboarding materials; used internal documentation instead.


------
https://chatgpt.com/codex/tasks/task_e_68e0488316788331a87540e8f90fb05f