### PR TITLE
Update Docker host port mapping for admin UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ PGPORT=5432
 
 # Admin interface settings
 ADMIN_PASSWORD=your-password
+APP_PORT=3001
+APP_HOST_PORT=31371
 ADMIN_PORT=3001
 # Secret used to sign session cookies (REQUIRED - generate a strong unique value)
 SESSION_SECRET=please-generate-a-strong-secret

--- a/README.md
+++ b/README.md
@@ -181,13 +181,16 @@
    ```bash
    docker compose up -d --build
    ```
-3. Open the admin UI at `http://localhost:3001` (or your `ADMIN_PORT`).
+3. Open the admin UI at `http://SERVER-IP:31371` (or your `APP_HOST_PORT`).
 4. Run migrations when needed:
    ```bash
    docker compose run --rm migrate
    ```
 5. View logs: `docker compose logs -f app` or `docker compose logs -f worker`.
 6. Stop all services: `docker compose down`.
+
+- Postgres (`db`) and Redis (`redis`) stay internal to the Docker network and are not published to the host.
+- Override the host port by setting `APP_HOST_PORT` in `.env`; the app keeps listening on the internal `APP_PORT` (default `3001`).
 
 ## الرخصة
 هذا المشروع موزع وفق رخصة MIT، ويمكنك الاطلاع على نص الرخصة في ملف [LICENSE](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     build: .
     env_file: .env
     environment:
+      APP_PORT: ${APP_PORT:-3001}
+      ADMIN_PORT: ${APP_PORT:-3001}
       PGHOST: db
       REDIS_URL: redis://redis:6379
       NODE_ENV: development
@@ -40,9 +42,9 @@ services:
         condition: service_healthy
     command: ['node', 'src/admin.js']
     ports:
-      - '${ADMIN_PORT:-3001}:3001'
+      - '${APP_HOST_PORT:-31371}:${APP_PORT:-3001}'
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://localhost:3001 || exit 1']
+      test: ['CMD-SHELL', 'wget -qO- "http://localhost:${APP_PORT:-3001}" || exit 1']
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- keep database and redis internal to the Docker network while wiring app port env defaults
- map the admin UI to a high-numbered host port with configurable APP_HOST_PORT/APP_PORT
- document the new defaults and lack of host exposure for internal services

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b6aff66c8331a2a8b301b3714a97)