### PR TITLE
Add demo seed script for demo organization and bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,23 @@
 - Postgres (`db`) and Redis (`redis`) stay internal to the Docker network and are not published to the host.
 - Override the host port by setting `APP_HOST_PORT` in `.env`; the app keeps listening on the internal `APP_PORT` (default `3001`).
 
+## Getting started: first demo bot
+1. Start the stack:
+   ```bash
+   docker compose up -d
+   ```
+2. Run migrations:
+   ```bash
+   docker compose run --rm migrate
+   ```
+3. Seed a demo organization and bot:
+   ```bash
+   docker compose run --rm app npm run seed:demo
+   ```
+4. Open the Admin UI at `http://<SERVER_IP>:${APP_HOST_PORT:-31371}` and sign in as `admin` using the password from `ADMIN_PASSWORD` in `.env`.
+5. Verify "Demo Organization" and the "Demo WhatsApp Bot" appear under its Bots page.
+6. Link WhatsApp by keeping the worker running, tailing logs with `docker compose logs -f worker`, opening the QR link it prints, and scanning it from WhatsApp > Linked Devices.
+
 ## الرخصة
 هذا المشروع موزع وفق رخصة MIT، ويمكنك الاطلاع على نص الرخصة في ملف [LICENSE](LICENSE).
 جميع حقوق النشر محفوظة لـ whatsapp-bot 2024.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:db": "node src/scripts/testConnectivity.js --db",
     "test:env": "node src/scripts/testConnectivity.js",
     "migrate": "node src/initDb.js",
+    "seed:demo": "node src/scripts/seedDemoBot.js",
     "worker": "node src/worker.js",
     "lint": "eslint \"src/**\" \"tests/**\""
   },

--- a/src/scripts/seedDemoBot.js
+++ b/src/scripts/seedDemoBot.js
@@ -1,0 +1,67 @@
+const { Pool } = require('pg');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+function createPool () {
+  const port = process.env.PGPORT ? parseInt(process.env.PGPORT, 10) : 5432;
+
+  return new Pool({
+    host: process.env.PGHOST,
+    user: process.env.PGUSER,
+    database: process.env.PGDATABASE,
+    password: process.env.PGPASSWORD,
+    port: Number.isNaN(port) ? 5432 : port
+  });
+}
+
+async function seedDemoBot () {
+  const pool = createPool();
+
+  try {
+    await pool.query('SELECT 1');
+    console.log('Connected to Postgres');
+
+    const orgResult = await pool.query(
+      `INSERT INTO organizations (name, created_at, updated_at)
+       VALUES ($1, NOW(), NOW())
+       ON CONFLICT (name) DO UPDATE
+         SET updated_at = EXCLUDED.updated_at
+       RETURNING id`,
+      ['Demo Organization']
+    );
+    const organizationId = orgResult.rows[0].id;
+    console.log(`Organization ID: ${organizationId}`);
+
+    const botResult = await pool.query(
+      `INSERT INTO bots (organization_id, assistant_id, name, phone, status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+       ON CONFLICT (assistant_id) DO UPDATE
+         SET organization_id = EXCLUDED.organization_id,
+             name = EXCLUDED.name,
+             phone = EXCLUDED.phone,
+             status = EXCLUDED.status,
+             updated_at = EXCLUDED.updated_at
+       RETURNING id`,
+      [
+        organizationId,
+        'demo-assistant',
+        'Demo WhatsApp Bot',
+        '+10000000000',
+        'active'
+      ]
+    );
+    const botId = botResult.rows[0].id;
+    console.log(`Bot ID: ${botId}`);
+
+    console.log('Demo seed completed successfully');
+  } catch (error) {
+    console.error('Seed failed:', error);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+    console.log('Postgres pool closed');
+  }
+}
+
+seedDemoBot();


### PR DESCRIPTION
## Summary
- add a demo seed script to provision a sample organization and WhatsApp bot via Postgres
- expose an npm seed:demo helper and document how to run it in Docker

## Testing
- npm test *(not run in this environment: npm/node unavailable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933cf0acfa48331bcdc9dd42397c569)