### PR TITLE
Align database schema and Redis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,20 @@
 - Override the host port by setting `APP_HOST_PORT` in `.env`; the app keeps listening on the internal `APP_PORT` (default `3001`).
 
 ## Database schema & initialization
-- المخطط المعتمد مذكور في `docs/schema.sql` ويتضمن الجداول الأساسية: organizations، users، whatsapp_bots، documents، conversations، messages، scheduled_messages، usage_stats، conversation_stats، unanswered_questions، faq_suggestions.
-- تهيئة قاعدة بيانات جديدة داخل Docker:
+- All tables are created via `migrations/*.js` using `BIGSERIAL` primary keys and `TIMESTAMPTZ` timestamps. Key relations:
+  - `organizations` own `whatsapp_bots`, `documents`, `conversations`, `scheduled_messages`, `usage_stats`, `unanswered_questions`, and `faq_suggestions` (CASCADE on delete where appropriate).
+  - `whatsapp_bots` are unique per organization/assistant/phone and track status + timestamps.
+  - `conversations` and `messages` cascade deletes with `conversation_stats` linked per message; `usage_stats` aggregate per organization.
+  - `users` may belong to an organization and store optional TOTP secrets.
+- Fresh Docker init:
   ```bash
-  docker compose up -d --build
+  docker compose up -d db redis
   docker compose run --rm migrate
-  ```
-- زرع بيانات تجريبية بعد التهيئة:
-  ```bash
   docker compose run --rm app npm run seed:demo
+  docker compose up -d
   ```
+- The seed script creates (or updates) a demo organization and WhatsApp bot; it is safe to re-run.
+- All Redis clients read `REDIS_URL` (defaults to `redis://redis:6379` in Docker).
 
 ## Getting started: first demo bot
 1. Start the stack:

--- a/migrations/000001_initial_schema.js
+++ b/migrations/000001_initial_schema.js
@@ -3,7 +3,7 @@ exports.shorthands = undefined;
 
 exports.up = pgm => {
   pgm.createTable('organizations', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     name: { type: 'text', notNull: true },
     phone: { type: 'text' },
     instructions: { type: 'text' },
@@ -11,25 +11,25 @@ exports.up = pgm => {
     language: { type: 'text', notNull: true, default: pgm.func("'ar'") },
     working_hours_start: { type: 'time' },
     working_hours_end: { type: 'time' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('documents', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
     file_id: { type: 'text' },
     file_name: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('conversations', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
@@ -38,13 +38,13 @@ exports.up = pgm => {
     escalated: { type: 'boolean', notNull: true, default: false },
     detected_language: { type: 'text' },
     summary: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('messages', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     conversation_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'conversations(id)',
       onDelete: 'CASCADE'
     },
@@ -52,88 +52,89 @@ exports.up = pgm => {
     text: { type: 'text', notNull: false, default: pgm.func("''") },
     attachment_type: { type: 'text' },
     attachment_path: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('scheduled_messages', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
     phone: { type: 'text', notNull: true },
     text: { type: 'text', notNull: true },
-    send_at: { type: 'timestamp', notNull: true },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    send_at: { type: 'timestamptz', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('usage_stats', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
     tokens_prompt: { type: 'integer', notNull: true },
     tokens_completion: { type: 'integer', notNull: true },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('conversation_stats', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     conversation_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'conversations(id)',
       onDelete: 'CASCADE'
     },
     response_time_ms: { type: 'integer', notNull: true },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('unanswered_questions', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     phone: { type: 'text', notNull: true },
     message: { type: 'text', notNull: true },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('faq_suggestions', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     question: { type: 'text', notNull: true, unique: true },
     count: { type: 'integer', notNull: true },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
-  pgm.createTable('bots', {
-    id: 'id',
-      organization_id: {
-        type: 'integer',
-        references: 'organizations(id)',
-        onDelete: 'CASCADE'
-      },
+  pgm.createTable('whatsapp_bots', {
+    id: { type: 'bigserial', primaryKey: true },
+    organization_id: {
+      type: 'bigint',
+      references: 'organizations(id)',
+      onDelete: 'CASCADE',
+      notNull: true
+    },
     assistant_id: { type: 'text' },
     name: { type: 'text' },
     phone: { type: 'text' },
     status: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createTable('users', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     username: { type: 'text', notNull: true, unique: true },
     password_hash: { type: 'text', notNull: true },
     role: { type: 'text', notNull: true, default: pgm.func("'admin'") },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)'
     },
     totp_secret: { type: 'text' }
   }, { ifNotExists: true });
 
-  pgm.createIndex('bots', 'organization_id', { ifNotExists: true });
-  pgm.createIndex('bots', 'assistant_id', { unique: true, ifNotExists: true });
-  pgm.createIndex('bots', 'phone', { unique: true, ifNotExists: true });
+  pgm.createIndex('whatsapp_bots', 'organization_id', { ifNotExists: true });
+  pgm.createIndex('whatsapp_bots', 'assistant_id', { unique: true, ifNotExists: true });
+  pgm.createIndex('whatsapp_bots', 'phone', { unique: true, ifNotExists: true });
   pgm.createIndex('messages', 'conversation_id', { ifNotExists: true });
   pgm.createIndex('conversations', 'customer_phone', { ifNotExists: true });
   pgm.createIndex('users', 'organization_id', { ifNotExists: true });
@@ -143,12 +144,12 @@ exports.down = pgm => {
   pgm.dropIndex('users', 'organization_id', { ifExists: true });
   pgm.dropIndex('conversations', 'customer_phone', { ifExists: true });
   pgm.dropIndex('messages', 'conversation_id', { ifExists: true });
-  pgm.dropIndex('bots', 'phone', { ifExists: true });
-  pgm.dropIndex('bots', 'assistant_id', { ifExists: true });
-  pgm.dropIndex('bots', 'organization_id', { ifExists: true });
+  pgm.dropIndex('whatsapp_bots', 'phone', { ifExists: true });
+  pgm.dropIndex('whatsapp_bots', 'assistant_id', { ifExists: true });
+  pgm.dropIndex('whatsapp_bots', 'organization_id', { ifExists: true });
 
   pgm.dropTable('users', { ifExists: true });
-  pgm.dropTable('bots', { ifExists: true });
+  pgm.dropTable('whatsapp_bots', { ifExists: true });
   pgm.dropTable('faq_suggestions', { ifExists: true });
   pgm.dropTable('unanswered_questions', { ifExists: true });
   pgm.dropTable('conversation_stats', { ifExists: true });

--- a/migrations/000002_schema_hardening.js
+++ b/migrations/000002_schema_hardening.js
@@ -4,7 +4,7 @@ exports.shorthands = undefined;
 exports.up = pgm => {
   // Organizations hardening
   pgm.addColumn('organizations', {
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   });
   pgm.createIndex('organizations', 'name', { unique: true, ifNotExists: true });
   pgm.createIndex('organizations', 'phone', {
@@ -22,7 +22,7 @@ exports.up = pgm => {
   pgm.addColumns('documents', {
     checksum: { type: 'text' },
     source_url: { type: 'text' },
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   });
   pgm.createIndex('documents', ['organization_id', 'file_id'], {
     unique: true,
@@ -33,11 +33,11 @@ exports.up = pgm => {
 
   // Conversations escalation context and dedupe
   pgm.addColumns('conversations', {
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    last_message_at: { type: 'timestamp' },
-    escalated_at: { type: 'timestamp' },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    last_message_at: { type: 'timestamptz' },
+    escalated_at: { type: 'timestamptz' },
     escalated_by: {
-      type: 'integer',
+      type: 'bigint',
       references: 'users(id)',
       onDelete: 'SET NULL'
     }
@@ -58,8 +58,8 @@ exports.up = pgm => {
   // Scheduled messages delivery feedback
   pgm.addColumns('scheduled_messages', {
     status: { type: 'text', notNull: true, default: pgm.func("'pending'") },
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    last_attempt_at: { type: 'timestamp' },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    last_attempt_at: { type: 'timestamptz' },
     error: { type: 'text' }
   });
   pgm.createIndex('scheduled_messages', ['organization_id', 'phone', 'send_at'], {
@@ -69,8 +69,8 @@ exports.up = pgm => {
 
   // Usage stats aggregation periods
   pgm.addColumns('usage_stats', {
-    period_start: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    period_end: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
+    period_start: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    period_end: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
     run_count: { type: 'integer', notNull: true, default: 0 },
     total_cost: { type: 'numeric', notNull: true, default: 0 }
   });
@@ -82,7 +82,7 @@ exports.up = pgm => {
   // Conversation stats traceability
   pgm.addColumns('conversation_stats', {
     message_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'messages(id)',
       onDelete: 'CASCADE'
     }
@@ -93,14 +93,14 @@ exports.up = pgm => {
   // Unanswered question routing
   pgm.addColumns('unanswered_questions', {
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
     handled: { type: 'boolean', notNull: true, default: false },
-    handled_at: { type: 'timestamp' },
+    handled_at: { type: 'timestamptz' },
     handled_by: {
-      type: 'integer',
+      type: 'bigint',
       references: 'users(id)',
       onDelete: 'SET NULL'
     }
@@ -111,11 +111,11 @@ exports.up = pgm => {
   pgm.dropConstraint('faq_suggestions', 'faq_suggestions_question_key', { ifExists: true });
   pgm.addColumns('faq_suggestions', {
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
-    last_suggested_at: { type: 'timestamp' }
+    last_suggested_at: { type: 'timestamptz' }
   });
   pgm.createIndex('faq_suggestions', ['organization_id', 'question'], {
     unique: true,
@@ -123,22 +123,22 @@ exports.up = pgm => {
   });
 
   // Bot + user auditing
-  pgm.addColumn('bots', {
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+  pgm.addColumn('whatsapp_bots', {
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   });
-  pgm.alterColumn('bots', 'organization_id', { notNull: true });
+  pgm.alterColumn('whatsapp_bots', 'organization_id', { notNull: true });
 
   pgm.addColumns('users', {
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    last_login_at: { type: 'timestamp' }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    last_login_at: { type: 'timestamptz' }
   });
 };
 
 exports.down = pgm => {
   pgm.dropColumns('users', ['last_login_at', 'updated_at', 'created_at']);
-  pgm.alterColumn('bots', 'organization_id', { notNull: false });
-  pgm.dropColumn('bots', 'updated_at');
+  pgm.alterColumn('whatsapp_bots', 'organization_id', { notNull: false });
+  pgm.dropColumn('whatsapp_bots', 'updated_at');
 
   pgm.dropIndex('faq_suggestions', ['organization_id', 'question'], { ifExists: true });
   pgm.dropColumn('faq_suggestions', 'last_suggested_at');

--- a/migrations/000003_whatsapp_bots.js
+++ b/migrations/000003_whatsapp_bots.js
@@ -3,9 +3,9 @@ exports.shorthands = undefined;
 
 exports.up = pgm => {
   pgm.createTable('whatsapp_bots', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       notNull: true,
       references: 'organizations(id)',
       onDelete: 'CASCADE'
@@ -14,8 +14,8 @@ exports.up = pgm => {
     name: { type: 'text' },
     phone: { type: 'text' },
     status: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createIndex('whatsapp_bots', 'organization_id', { ifNotExists: true });
@@ -42,9 +42,9 @@ exports.up = pgm => {
 
 exports.down = pgm => {
   pgm.createTable('bots', {
-    id: 'id',
+    id: { type: 'bigserial', primaryKey: true },
     organization_id: {
-      type: 'integer',
+      type: 'bigint',
       references: 'organizations(id)',
       onDelete: 'CASCADE'
     },
@@ -52,8 +52,8 @@ exports.down = pgm => {
     name: { type: 'text' },
     phone: { type: 'text' },
     status: { type: 'text' },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') },
-    updated_at: { type: 'timestamp', notNull: true, default: pgm.func('now()') }
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   }, { ifNotExists: true });
 
   pgm.createIndex('bots', 'organization_id', { ifNotExists: true });

--- a/src/checkEnv.js
+++ b/src/checkEnv.js
@@ -2,14 +2,13 @@ const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
 const { Client } = require('pg');
-const Redis = require('ioredis');
 const logger = require('./logger');
+const { createRedisClient, redisUrl } = require('./redisConfig');
 
 dotenv.config();
 
 const REQUIRED_PG_ENV = ['PGHOST', 'PGUSER', 'PGDATABASE', 'PGPASSWORD', 'PGPORT'];
 let cachedPromise;
-const redisUrl = process.env.REDIS_URL || 'redis://redis:6379';
 
 function ensureOpenAIKey () {
   if (!process.env.OPENAI_API_KEY) {
@@ -105,7 +104,7 @@ async function ensureWhatsAppAuthFolders (client) {
 }
 
 async function ensureRedisReady () {
-  const redis = new Redis(redisUrl, { lazyConnect: true });
+  const redis = createRedisClient({ lazyConnect: true });
 
   try {
     logger.info(`Checking Redis connectivity at: ${redisUrl}`);

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,11 +1,8 @@
 const { Queue } = require('bullmq');
-require('dotenv').config();
+const { redisConnection } = require('./redisConfig');
 
-const redisUrl = process.env.REDIS_URL || 'redis://redis:6379';
-const connection = { url: redisUrl };
-
-const messageQueue = new Queue('messages', { connection });
-const bulkQueue = new Queue('bulkMessages', { connection });
+const messageQueue = new Queue('messages', { connection: redisConnection });
+const bulkQueue = new Queue('bulkMessages', { connection: redisConnection });
 
 async function getQueueLength () {
   const regular = await messageQueue.getWaitingCount();

--- a/src/redisConfig.js
+++ b/src/redisConfig.js
@@ -1,0 +1,15 @@
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const DEFAULT_REDIS_URL = 'redis://redis:6379';
+const redisUrl = process.env.REDIS_URL || DEFAULT_REDIS_URL;
+const redisConnection = { url: redisUrl };
+
+function createRedisClient (options = {}) {
+  const Redis = require('ioredis');
+  const { url, ...redisOptions } = options;
+  return new Redis(url || redisUrl, redisOptions);
+}
+
+module.exports = { redisUrl, redisConnection, createRedisClient };

--- a/src/redisVersion.js
+++ b/src/redisVersion.js
@@ -1,4 +1,4 @@
-const Redis = require('ioredis');
+const { createRedisClient, redisUrl } = require('./redisConfig');
 
 const MIN_REDIS_VERSION = '6.2.0';
 
@@ -47,12 +47,9 @@ function parseVersionFromInfo (info) {
 }
 
 async function ensureRedisVersion (options = {}) {
-  const {
-    url = process.env.REDIS_URL || 'redis://redis:6379',
-    minVersion = MIN_REDIS_VERSION
-  } = options;
+  const { url = redisUrl, minVersion = MIN_REDIS_VERSION } = options;
 
-  const redis = new Redis(url, { lazyConnect: true });
+  const redis = createRedisClient({ url, lazyConnect: true });
 
   try {
     await redis.connect();

--- a/src/scripts/migrateBots.js
+++ b/src/scripts/migrateBots.js
@@ -3,19 +3,19 @@ const logger = require('../logger');
 
 async function migrate () {
   await pool.query(
-    'ALTER TABLE users ADD COLUMN IF NOT EXISTS organization_id INTEGER REFERENCES organizations(id)'
+    'ALTER TABLE users ADD COLUMN IF NOT EXISTS organization_id BIGINT REFERENCES organizations(id)'
   );
 
   await pool.query(`
     CREATE TABLE IF NOT EXISTS whatsapp_bots (
-      id SERIAL PRIMARY KEY,
-      organization_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
+      id BIGSERIAL PRIMARY KEY,
+      organization_id BIGINT REFERENCES organizations(id) ON DELETE CASCADE,
       assistant_id TEXT,
       name TEXT,
       phone TEXT,
       status TEXT,
-      created_at TIMESTAMP DEFAULT NOW(),
-      updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
     );
   `);
 

--- a/src/scripts/testConnectivity.js
+++ b/src/scripts/testConnectivity.js
@@ -1,7 +1,5 @@
 const { Client } = require('pg');
-const Redis = require('ioredis');
-
-const redisUrl = process.env.REDIS_URL || 'redis://redis:6379';
+const { createRedisClient, redisUrl } = require('../redisConfig');
 
 function getPgConfig () {
   const config = {
@@ -23,7 +21,7 @@ function getPgConfig () {
 
 async function testRedis () {
   console.log(`Testing Redis at ${redisUrl}`);
-  const redis = new Redis(redisUrl, { lazyConnect: true });
+  const redis = createRedisClient({ url: redisUrl, lazyConnect: true });
 
   try {
     await redis.connect();

--- a/src/worker.js
+++ b/src/worker.js
@@ -20,6 +20,7 @@ const { startScheduler } = require('./scheduler');
 const { getSocket, startBot } = require('./botManager');
 const { messageQueue, bulkQueue } = require('./queue');
 const { MIN_REDIS_VERSION, ensureRedisVersion } = require('./redisVersion');
+const { redisConnection, redisUrl } = require('./redisConfig');
 
 const FAST_DEV = process.env.FAST_DEV === 'true';
 
@@ -33,9 +34,6 @@ function resolveIntEnv (name, defaultValue, devDefault) {
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : fallback;
 }
-
-const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
-const redisConnection = { url: REDIS_URL };
 
 const MIN_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 60000;
@@ -508,7 +506,7 @@ async function bootstrap () {
   }
 
   try {
-    const version = await ensureRedisVersion({ url: REDIS_URL, minVersion: MIN_REDIS_VERSION });
+    const version = await ensureRedisVersion({ url: redisUrl, minVersion: MIN_REDIS_VERSION });
     logger.info(`Redis version ${version} verified (required ≥ ${MIN_REDIS_VERSION}).`);
   } catch (error) {
     if (error.code === 'REDIS_VERSION_UNSUPPORTED') {


### PR DESCRIPTION
## Summary
- standardize migrations on the whatsapp_bots table with BIGSERIAL/TIMESTAMPTZ columns and updated relationships
- centralize Redis configuration so all clients read REDIS_URL and share one connection setup
- refresh documentation for running migrations and seeding demo data

## Testing
- npm test *(fails: `npm` command unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933de61f4548331b73834641a6fa134)