### PR TITLE
Ensure whatsapp bot schema and docker startup are consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,21 @@
    docker compose up -d --build
    ```
 3. Open the admin UI at `http://SERVER-IP:31371` (or your `APP_HOST_PORT`).
-4. Run migrations when needed:
+4. Run migrations (idempotent, also executed automatically before app/worker start):
    ```bash
    docker compose run --rm migrate
    ```
-5. View logs: `docker compose logs -f app` or `docker compose logs -f worker`.
-6. Stop all services: `docker compose down`.
+5. Seed demo data:
+   ```bash
+   docker compose run --rm app npm run seed:demo
+   ```
+6. View logs: `docker compose logs -f app` or `docker compose logs -f worker`.
+7. Reset everything (including Postgres volume) then re-run steps 2–5:
+   ```bash
+   docker compose down -v
+   ```
+
+- Redis is configured via `REDIS_URL` (defaults to `redis://redis:6379` in Docker). Postgres uses `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `PGPORT`.
 
 - Postgres (`db`) and Redis (`redis`) stay internal to the Docker network and are not published to the host.
 - Override the host port by setting `APP_HOST_PORT` in `.env`; the app keeps listening on the internal `APP_PORT` (default `3001`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: ['node', 'src/admin.js']
+    command: ['sh', '-c', 'npm run migrate && node src/admin.js']
     ports:
       - '${APP_HOST_PORT:-31371}:${APP_PORT:-3001}'
     healthcheck:
@@ -70,7 +70,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: ['node', 'src/worker.js']
+    command: ['sh', '-c', 'npm run migrate && node src/worker.js']
     restart: unless-stopped
 
   migrate:

--- a/migrations/000003_whatsapp_bots.js
+++ b/migrations/000003_whatsapp_bots.js
@@ -2,22 +2,6 @@
 exports.shorthands = undefined;
 
 exports.up = pgm => {
-  pgm.createTable('whatsapp_bots', {
-    id: { type: 'bigserial', primaryKey: true },
-    organization_id: {
-      type: 'bigint',
-      notNull: true,
-      references: 'organizations(id)',
-      onDelete: 'CASCADE'
-    },
-    assistant_id: { type: 'text' },
-    name: { type: 'text' },
-    phone: { type: 'text' },
-    status: { type: 'text' },
-    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
-    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
-  }, { ifNotExists: true });
-
   pgm.createIndex('whatsapp_bots', 'organization_id', { ifNotExists: true });
   pgm.createIndex('whatsapp_bots', 'assistant_id', { unique: true, ifNotExists: true });
   pgm.createIndex('whatsapp_bots', 'phone', { unique: true, ifNotExists: true });

--- a/migrations/000004_whatsapp_bots_refine.js
+++ b/migrations/000004_whatsapp_bots_refine.js
@@ -1,0 +1,27 @@
+/* eslint-disable camelcase */
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.addColumns('whatsapp_bots', {
+    session_folder: { type: 'text' },
+    active: { type: 'boolean', notNull: true, default: pgm.func("'true'") }
+  });
+
+  pgm.alterColumn('whatsapp_bots', 'status', { notNull: true, default: pgm.func("'stopped'") });
+  pgm.alterColumn('whatsapp_bots', 'created_at', { notNull: true, default: pgm.func('now()') });
+  pgm.alterColumn('whatsapp_bots', 'updated_at', { notNull: true, default: pgm.func('now()') });
+  pgm.alterColumn('whatsapp_bots', 'organization_id', { notNull: true });
+
+  pgm.createIndex('whatsapp_bots', ['organization_id', 'active'], {
+    ifNotExists: true
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropIndex('whatsapp_bots', ['organization_id', 'active'], { ifExists: true });
+  pgm.alterColumn('whatsapp_bots', 'organization_id', { notNull: false });
+  pgm.alterColumn('whatsapp_bots', 'updated_at', { default: null, notNull: false });
+  pgm.alterColumn('whatsapp_bots', 'created_at', { default: null, notNull: false });
+  pgm.alterColumn('whatsapp_bots', 'status', { default: null, notNull: false });
+  pgm.dropColumns('whatsapp_bots', ['session_folder', 'active']);
+};

--- a/src/checkEnv.js
+++ b/src/checkEnv.js
@@ -81,7 +81,21 @@ function hasAuthFolder (botId) {
 }
 
 async function ensureWhatsAppAuthFolders (client) {
-  const { rows } = await client.query('SELECT id, name, phone FROM whatsapp_bots ORDER BY id');
+  let botsResult;
+  try {
+    botsResult = await client.query('SELECT id, name, phone FROM whatsapp_bots ORDER BY id');
+  } catch (error) {
+    if (error.code === '42P01') {
+      const missingTableError = new Error(
+        'Table "whatsapp_bots" is missing. Run the migrations (npm run migrate or docker compose run --rm migrate) before starting the app.'
+      );
+      missingTableError.code = 'TABLES_NOT_MIGRATED';
+      missingTableError.cause = error;
+      throw missingTableError;
+    }
+    throw error;
+  }
+  const { rows } = botsResult;
   if (!rows.length) {
     return;
   }


### PR DESCRIPTION
## Summary
- add a whatsapp bot schema refinement migration with session folders, active flags, and stricter defaults
- remove redundant table creation, improve missing-table messaging, and run migrations before app/worker startup
- document docker migration/reset/seed steps and environment variables for Postgres and Redis

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e2772a2c83319b1a91bb1967141f)