### PR TITLE
Fix demo seed assistant handling

### DIFF
--- a/src/scripts/seedDemoBot.js
+++ b/src/scripts/seedDemoBot.js
@@ -36,16 +36,16 @@ async function seedDemoBot () {
     const botResult = await pool.query(
       `INSERT INTO bots (organization_id, assistant_id, name, phone, status, created_at, updated_at)
        VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-       ON CONFLICT (assistant_id) DO UPDATE
+       ON CONFLICT (phone) DO UPDATE
          SET organization_id = EXCLUDED.organization_id,
+             assistant_id = COALESCE(bots.assistant_id, EXCLUDED.assistant_id),
              name = EXCLUDED.name,
-             phone = EXCLUDED.phone,
              status = EXCLUDED.status,
              updated_at = EXCLUDED.updated_at
        RETURNING id`,
       [
         organizationId,
-        'demo-assistant',
+        null,
         'Demo WhatsApp Bot',
         '+10000000000',
         'active'


### PR DESCRIPTION
## Summary
- remove fake assistant id from demo bot seed and allow assistant provisioning to occur
- upsert demo bot by phone while preserving any existing assistant id

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ebbb394c8331893b2283b9b28129)