### PR TITLE
Fix demo seed bot table and conflict clause

### DIFF
--- a/src/scripts/seedDemoBot.js
+++ b/src/scripts/seedDemoBot.js
@@ -34,11 +34,12 @@ async function seedDemoBot () {
     console.log(`Organization ID: ${organizationId}`);
 
     const botResult = await pool.query(
-      `INSERT INTO whatsapp_bots (organization_id, assistant_id, name, phone, status, created_at, updated_at)
+      `INSERT INTO bots (organization_id, assistant_id, name, phone, status, created_at, updated_at)
        VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-       ON CONFLICT (organization_id, name) DO UPDATE
-         SET assistant_id = EXCLUDED.assistant_id,
-             phone = EXCLUDED.phone,
+       ON CONFLICT (phone) DO UPDATE
+         SET organization_id = EXCLUDED.organization_id,
+             assistant_id = EXCLUDED.assistant_id,
+             name = EXCLUDED.name,
              status = EXCLUDED.status,
              updated_at = EXCLUDED.updated_at
        RETURNING id`,


### PR DESCRIPTION
## Summary
- target the existing `bots` table in the demo seed script
- upsert demo bot using the unique `phone` constraint to avoid conflicts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ec5fd4b08331bf5004ff8b4a9934)