### PR TITLE
Stabilize backend startup for fresh environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:db": "node src/scripts/testConnectivity.js --db",
     "test:env": "node src/scripts/testConnectivity.js",
     "migrate": "node src/initDb.js",
-    "seed:demo": "node src/scripts/seedDemoBot.js",
+    "seed:demo": "node src/seedDemo.js",
     "worker": "node src/worker.js",
     "lint": "eslint \"src/**\" \"tests/**\""
   },

--- a/src/admin.js
+++ b/src/admin.js
@@ -208,7 +208,13 @@ function buildAllowedOrigins () {
   envOrigins.forEach(origin => origins.add(origin));
 
   if (process.env.NODE_ENV !== 'production') {
-    ['http://localhost:3000', 'http://localhost:4173', 'http://localhost:5173'].forEach(origin => origins.add(origin));
+    [
+      'http://localhost',
+      'http://127.0.0.1',
+      'http://localhost:3000',
+      'http://localhost:4173',
+      'http://localhost:5173'
+    ].forEach(origin => origins.add(origin));
   }
 
   return origins;
@@ -231,9 +237,10 @@ function corsMiddleware (req, res, next) {
   next();
 }
 
+app.use(corsMiddleware);
+
 const apiRouter = express.Router();
 // All API endpoints are now mounted under `/api` for the external frontend SPA (legacy paths remain as compatibility aliases).
-apiRouter.use(corsMiddleware);
 
 function registerApiRoute (method, path, handlers, legacyPaths = []) {
   apiRouter[method](path, ...handlers);
@@ -258,6 +265,14 @@ botEvents.on('update', data => {
   const payload = JSON.stringify(data);
   wsClients.forEach(client => {
     try { client.send(payload); } catch (e) {}
+  });
+});
+
+app.get('/api/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString()
   });
 });
 

--- a/src/checkEnv.js
+++ b/src/checkEnv.js
@@ -77,17 +77,16 @@ async function ensureWhatsAppAuthFolders (client) {
     botsResult = await client.query('SELECT id, name, phone FROM whatsapp_bots ORDER BY id');
   } catch (error) {
     if (error.code === '42P01') {
-      const missingTableError = new Error(
-        'Table "whatsapp_bots" is missing. Run the migrations (npm run migrate or docker compose run --rm migrate) before starting the app.'
+      logger.warn(
+        'Table "whatsapp_bots" is missing. Run the migrations (npm run migrate or docker compose run --rm migrate) to enable bot management.'
       );
-      missingTableError.code = 'TABLES_NOT_MIGRATED';
-      missingTableError.cause = error;
-      throw missingTableError;
+      return;
     }
     throw error;
   }
   const { rows } = botsResult;
   if (!rows.length) {
+    logger.warn('No bots found in database. Add a bot to enable WhatsApp connections.');
     return;
   }
 
@@ -100,11 +99,8 @@ async function ensureWhatsAppAuthFolders (client) {
   }
 
   if (missing.length) {
-    const error = new Error('Missing WhatsApp auth folders');
-    error.code = 'MISSING_WHATSAPP_AUTH_FOLDERS';
-    error.details = missing;
-    logger.error('Missing WhatsApp auth folders', { missing });
-    throw error;
+    logger.warn('Missing WhatsApp auth folders', { missing });
+    return;
   }
 
   logger.info(`WhatsApp auth base directory ready at ${baseDir}.`);

--- a/src/initDb.js
+++ b/src/initDb.js
@@ -18,7 +18,15 @@ async function runMigrations () {
   await client.connect();
 
   try {
-    await runner({
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS pgmigrations (
+        id bigserial PRIMARY KEY,
+        name text UNIQUE NOT NULL,
+        run_on timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    const executedMigrations = await runner({
       dbClient: client,
       dir: path.resolve(__dirname, '..', 'migrations'),
       direction: 'up',
@@ -26,6 +34,12 @@ async function runMigrations () {
       migrationsTable: 'pgmigrations',
       logger
     });
+
+    if (!executedMigrations.length) {
+      logger.info('No migrations to run');
+    } else {
+      logger.info(`Applied ${executedMigrations.length} migration(s)`);
+    }
   } finally {
     await client.end();
   }

--- a/src/seedDemo.js
+++ b/src/seedDemo.js
@@ -1,0 +1,58 @@
+const pool = require('./db');
+const logger = require('./logger');
+const { slugify } = require('./utils/slugify');
+
+async function seedDemo () {
+  const client = await pool.connect();
+  const orgSlug = 'org-1';
+  const botName = 'Org-1-Bot';
+
+  try {
+    await client.query('BEGIN');
+
+    const orgResult = await client.query(
+      `INSERT INTO organizations (name, slug, status)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (slug) DO UPDATE
+       SET name = EXCLUDED.name,
+           status = EXCLUDED.status,
+           updated_at = now()
+       RETURNING id, name, slug, status`,
+      ['Org-1', slugify(orgSlug), 'active']
+    );
+    const organization = orgResult.rows[0];
+    logger.info(`Seeded organization ${organization.slug}`, organization);
+
+    const botResult = await client.query(
+      `INSERT INTO whatsapp_bots (organization_id, assistant_id, name, phone, status)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (organization_id, name) DO UPDATE
+       SET phone = EXCLUDED.phone,
+           status = EXCLUDED.status,
+           updated_at = now()
+       RETURNING id, name, status`,
+      [organization.id, 'demo-assistant', botName, '0000000000000', 'stopped']
+    );
+    const bot = botResult.rows[0];
+    logger.info(`Seeded bot ${bot.name}`, bot);
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    logger.error('Demo seed failed', error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  seedDemo().then(() => {
+    if (!process.exitCode) {
+      logger.info('Demo seed completed');
+    }
+  });
+}
+
+module.exports = { seedDemo };

--- a/tests/checkEnv.test.js
+++ b/tests/checkEnv.test.js
@@ -114,7 +114,8 @@ describe('checkEnv', () => {
     expect(mockRedisInstance.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  test('throws when WhatsApp auth folders are missing', async () => {
+  test('warns when WhatsApp auth folders are missing', async () => {
+    const logger = require('../src/logger');
     mockClient.query.mockImplementation(async sql => {
       if (sql === 'SELECT 1') {
         return { rows: [] };
@@ -127,6 +128,7 @@ describe('checkEnv', () => {
     mockFsModule.existsSync.mockReturnValue(false);
 
     const { checkEnv } = require('../src/checkEnv');
-    await expect(checkEnv()).rejects.toThrow('Missing WhatsApp auth folders');
+    await expect(checkEnv()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/tests/initDbScript.test.js
+++ b/tests/initDbScript.test.js
@@ -30,16 +30,17 @@ describe('initDb script', () => {
       error: jest.fn(),
       warn: jest.fn()
     };
-    const runner = jest.fn().mockResolvedValue(undefined);
+    const runner = jest.fn().mockResolvedValue([]);
     const hash = jest.fn().mockResolvedValue('hashed');
     const clientConnect = jest.fn().mockResolvedValue(undefined);
     const clientEnd = jest.fn().mockResolvedValue(undefined);
+    const clientQuery = jest.fn().mockResolvedValue({ rows: [] });
 
     jest.doMock('../src/db', () => pool);
     jest.doMock('../src/logger', () => logger);
     jest.doMock('bcrypt', () => ({ hash }));
     jest.doMock('node-pg-migrate', () => ({ runner }));
-    jest.doMock('pg', () => ({ Client: jest.fn(() => ({ connect: clientConnect, end: clientEnd })) }));
+    jest.doMock('pg', () => ({ Client: jest.fn(() => ({ connect: clientConnect, end: clientEnd, query: clientQuery })) }));
 
     let initDb;
     jest.isolateModules(() => {
@@ -48,6 +49,7 @@ describe('initDb script', () => {
 
     await initDb.main();
 
+    expect(clientQuery).toHaveBeenCalledWith(expect.stringContaining('CREATE TABLE IF NOT EXISTS pgmigrations'));
     expect(runner).toHaveBeenCalledTimes(1);
     expect(clientConnect).toHaveBeenCalledTimes(1);
     expect(clientEnd).toHaveBeenCalledTimes(1);
@@ -74,12 +76,13 @@ describe('initDb script', () => {
     const runner = jest.fn().mockRejectedValue(runnerError);
     const clientConnect = jest.fn().mockResolvedValue(undefined);
     const clientEnd = jest.fn().mockResolvedValue(undefined);
+    const clientQuery = jest.fn().mockResolvedValue({ rows: [] });
 
     jest.doMock('../src/db', () => pool);
     jest.doMock('../src/logger', () => logger);
     jest.doMock('bcrypt', () => ({ hash: jest.fn().mockResolvedValue('hashed') }));
     jest.doMock('node-pg-migrate', () => ({ runner }));
-    jest.doMock('pg', () => ({ Client: jest.fn(() => ({ connect: clientConnect, end: clientEnd })) }));
+    jest.doMock('pg', () => ({ Client: jest.fn(() => ({ connect: clientConnect, end: clientEnd, query: clientQuery })) }));
 
     let initDb;
     jest.isolateModules(() => {
@@ -88,6 +91,7 @@ describe('initDb script', () => {
 
     await initDb.main();
 
+    expect(clientQuery).toHaveBeenCalledWith(expect.stringContaining('CREATE TABLE IF NOT EXISTS pgmigrations'));
     expect(runner).toHaveBeenCalledTimes(1);
     expect(clientConnect).toHaveBeenCalledTimes(1);
     expect(clientEnd).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- add a health endpoint and broaden centralized CORS handling for API calls
- relax environment checks and migration bootstrapping to tolerate empty databases
- add an idempotent demo seed script for organizations/bots and update coverage

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69352729a6bc833180f5f1e9dc1e59a2)