### PR TITLE
Remove frontend service from docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,16 +104,5 @@ services:
         condition: service_healthy
     command: ['npm', 'run', 'migrate']
 
-  frontend:
-    build:
-      context: ../whatsapp-bot-frontend
-    environment:
-      API_BASE_URL: ${API_BASE_URL:-http://app:3000}
-    depends_on:
-      app:
-        condition: service_started
-    ports:
-      - '${FRONTEND_HOST_PORT:-4173}:80'
-
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- remove the frontend service from docker-compose now that the UI lives in its own project

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69353bb1871c8331bb27a0bcdcd8dbf0)