### PR TITLE
Add frontend service to compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       redis:
         condition: service_healthy
     command: ['sh', '-c', 'npm run migrate && node src/admin.js']
-    ports:
-      - '${APP_HOST_PORT:-31371}:${APP_PORT:-3001}'
+    expose:
+      - '${APP_PORT:-3001}'
     volumes:
       - ./whatsapp-auth:/app/whatsapp-auth
     healthcheck:
@@ -81,6 +81,16 @@ services:
     command: ['sh', '-c', 'npm run migrate && node src/worker.js']
     volumes:
       - ./whatsapp-auth:/app/whatsapp-auth
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ../whatsapp-bot-frontend
+    depends_on:
+      app:
+        condition: service_healthy
+    ports:
+      - '31372:80'
     restart: unless-stopped
 
   migrate:


### PR DESCRIPTION
## Summary
- add frontend service to compose stack building from sibling frontend repo
- expose backend internally and publish frontend via port 31372

## Testing
- docker compose config (fails: docker command not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354367b0508331bf288b8f70e76174)