### PR TITLE
Add SPA auth refactor plan and API auth bridge

### DIFF
--- a/docs/SPA_AUTH_REFACTOR_PLAN.md
+++ b/docs/SPA_AUTH_REFACTOR_PLAN.md
@@ -1,0 +1,63 @@
+# SPA Authentication Refactor Plan
+
+## Background & Problem Summary
+The current backend couples authentication to legacy EJS pages via Express sessions and CSRF, redirecting unauthenticated traffic to `/login` and expecting session-backed role checks. The SPA frontend issues stateless API calls without sessions, triggering 302 redirects and 403/401 errors. Mixed HTML and JSON responses further complicate integration, and CSRF/session assumptions bleed into `/api` routes.
+
+## Detailed Technical Risks
+- Global session + CSRF middleware block API calls lacking cookies/tokens.
+- `requireLogin` redirects instead of returning JSON, breaking XHR clients.
+- Role/org/bot checks (`requireAdmin`, `requireEditor`, `requireOrgAccess`, `requireBotAccess`) rely solely on `req.session.*` and emit HTML/text responses.
+- Legacy handlers reuse redirects for success/failure even when mounted under `/api`.
+- No API-native login/logout endpoints; SPA cannot establish auth context.
+- Cookie settings assume same-site delivery; cross-origin SPA may not send them.
+- API and admin share middleware stack, so changes risk breaking the admin panel.
+
+## Conflict Inventory
+- All `/api/*` routes require legacy session + CSRF and redirect on missing auth.
+- POST/PUT/PATCH/DELETE blocked by CSRF token requirements not exposed to SPA.
+- Org/bot/user management endpoints expect `req.session.role`/`organization_id`.
+- Upload/bot creation handlers mix redirects and JSON depending on `Accept`.
+- Metrics endpoint intentionally unauthenticated; must remain so.
+- WebSocket clients piggyback on session auth but are unaudited for SPA flows.
+
+## Full Remediation Plan
+- Introduce API-first auth layer (JWT or API cookie) alongside legacy sessions; expose `/api/auth/*` endpoints for SPA.
+- Guard `/api` with dedicated middleware that returns JSON (401/403) and can be bypassed via env flag during migration.
+- Keep legacy session + CSRF for EJS routes; decouple middleware stacks so admin and API evolve independently.
+- Normalize `/api` responses to JSON `{ error, message }`; remove redirects/HTML from API code paths.
+- Embed role/org info in API auth context (e.g., `req.user`) to power authorization checks without session coupling.
+- Document CORS/cookie requirements and standardize error payloads.
+- Add auth-focused integration tests to prevent regressions.
+
+## Step-by-Step Refactor Phases
+1. **Bridge (current change)**: Add `DISABLE_AUTH_FOR_API` flag to bypass auth/CSRF expectations on `/api`; introduce API middleware that emits JSON errors; preserve admin behavior.
+2. **API Auth Surface**: Scaffold `/api/auth/login|logout|refresh` endpoints; decide on JWT vs. API cookie; wire middleware to validate tokens and populate `req.user`.
+3. **Route Normalization**: Update all `/api` handlers to return JSON only and rely on `req.user` for roles/org access; keep legacy redirects for admin pages.
+4. **Hardening**: Remove bypass flag in production configs; enforce CORS/credentials, add rate limits/lockouts, and observability around auth failures.
+
+## Backward Compatibility Considerations
+- Legacy `/login`, admin pages, and CSRF-protected forms remain unchanged.
+- Session-based role checks stay active for non-API routes.
+- Metrics/WebSocket behavior preserved; new API auth runs alongside existing sessions.
+- Env flag defaults to secure mode; opting in is explicit and documented.
+
+## API Contract Adjustments
+- Standardize error payloads: `{ error: 'unauthorized'|'forbidden'|..., message: '...' }` with status codes 401/403 for auth issues.
+- `/api` must never issue redirects or HTML; responses are JSON or status-only.
+- Future `/api/auth/*` endpoints will exchange credentials for tokens/cookies and return user/role metadata.
+
+## Testing Plan
+- Unit tests for API auth middleware: unauthorized, forbidden, bypass flag behavior, and role/org access checks.
+- Integration tests for representative `/api` routes ensuring JSON errors and no redirects.
+- Regression tests for legacy admin flows (CSRF tokens, redirects) to confirm isolation.
+
+## Migration Notes
+- Deploy with `DISABLE_AUTH_FOR_API=true` only in non-prod to unblock SPA while frontend implements real login.
+- Coordinate SPA changes to consume `/api/auth/*` and send credentials (cookie or bearer token).
+- After SPA migration, disable the bypass and remove reliance on legacy session headers for API calls.
+
+## “Successful State” Definition
+- `/api/*` authenticated via API-first mechanism (token or API cookie), returning JSON-only responses with consistent error formats.
+- Legacy admin routes continue to use session + CSRF and redirects as before.
+- Role/org/bot checks read from unified `req.user` context, not legacy session-only fields.
+- No unexpected 302/403 responses for authorized SPA clients; metrics/WebSocket flows remain operational.

--- a/src/admin.js
+++ b/src/admin.js
@@ -36,6 +36,19 @@ const {
 } = require('./botManager');
 
 const sessionSecret = process.env.SESSION_SECRET;
+const apiAuthBypass = process.env.DISABLE_AUTH_FOR_API === 'true';
+
+function isApiRequest (req) {
+  return req.baseUrl?.startsWith('/api') || req.originalUrl?.startsWith('/api');
+}
+
+function isApiAuthDisabled (req) {
+  return apiAuthBypass && isApiRequest(req);
+}
+
+function jsonError (res, status, error, message) {
+  return res.status(status).json({ error, message: message || error });
+}
 
 function ensureSessionSecret () {
   if (!sessionSecret) {
@@ -62,6 +75,10 @@ app.use(expressLayouts);
 app.set('layout', 'layout');
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
+app.use((req, _res, next) => {
+  req.isApiRequest = isApiRequest(req);
+  next();
+});
 app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 app.use('/static', express.static(path.join(__dirname, '../public')));
 app.use(
@@ -78,7 +95,10 @@ app.use(
 );
 
 const csrfProtection = csrf();
-app.use(csrfProtection);
+app.use((req, res, next) => {
+  if (req.isApiRequest) return next();
+  csrfProtection(req, res, next);
+});
 
 // expose alert stored in session
 app.use((req, res, next) => {
@@ -104,24 +124,33 @@ app.use((req, res, next) => {
 });
 
 function requireAdmin (req, res, next) {
-  if (req.session.role === 'admin') return next();
+  const role = req.user?.role || req.session.role;
+  if (isApiAuthDisabled(req)) return next();
+  if (role === 'admin') return next();
+  if (req.isApiRequest) return jsonError(res, 403, 'forbidden', 'Admin role required');
   res.status(403).send('Forbidden');
 }
 
 function requireEditor (req, res, next) {
-  if (req.session.role === 'admin' || req.session.role === 'editor') return next();
+  const role = req.user?.role || req.session.role;
+  if (isApiAuthDisabled(req)) return next();
+  if (role === 'admin' || role === 'editor') return next();
+  if (req.isApiRequest) return jsonError(res, 403, 'forbidden', 'Editor role required');
   res.status(403).send('Forbidden');
 }
 
 function requireOrgAccess (req, res, next) {
-  if (req.session.role === 'admin') return next();
-  const orgId = req.session.organization_id;
+  const role = req.user?.role || req.session.role;
+  if (role === 'admin') return next();
+  if (isApiAuthDisabled(req)) return next();
+  const orgId = req.user?.organization_id || req.session.organization_id;
   const target =
     req.params.id ||
     req.params.orgId ||
     req.body.organization_id ||
     req.query.organization_id;
   if (target && Number(target) !== Number(orgId)) {
+    if (req.isApiRequest) return jsonError(res, 403, 'forbidden', 'Organization access required');
     return res.status(403).send('Forbidden');
   }
   next();
@@ -170,13 +199,17 @@ function isValidEmail (email) {
 }
 
 async function requireBotAccess (req, res, next) {
-  if (req.session.role === 'admin') return next();
+  const role = req.user?.role || req.session.role;
+  if (role === 'admin') return next();
+  if (isApiAuthDisabled(req)) return next();
   try {
     const { rows } = await pool.query('SELECT organization_id FROM whatsapp_bots WHERE id=$1', [
       req.params.botId
     ]);
     const orgId = rows[0]?.organization_id;
-    if (!orgId || Number(orgId) !== Number(req.session.organization_id)) {
+    const userOrg = req.user?.organization_id || req.session.organization_id;
+    if (!orgId || Number(orgId) !== Number(userOrg)) {
+      if (req.isApiRequest) return jsonError(res, 403, 'forbidden', 'Bot access denied');
       return res.status(403).send('Forbidden');
     }
     next();
@@ -187,8 +220,33 @@ async function requireBotAccess (req, res, next) {
 
 function requireLogin (req, res, next) {
   if (req.method === 'OPTIONS') return next();
-  if (req.session.user) return next();
+  if (isApiAuthDisabled(req)) return next();
+  if (req.session.user) {
+    if (req.isApiRequest) {
+      req.user = {
+        username: req.session.user,
+        role: req.session.role,
+        organization_id: req.session.organization_id
+      };
+    }
+    return next();
+  }
+  if (req.isApiRequest) return jsonError(res, 401, 'unauthorized', 'Login required');
   res.redirect('/login');
+}
+
+function apiAuthMiddleware (req, res, next) {
+  if (!req.isApiRequest) return next();
+  if (isApiAuthDisabled(req)) return next();
+  if (req.session.user) {
+    req.user = {
+      username: req.session.user,
+      role: req.session.role,
+      organization_id: req.session.organization_id
+    };
+    return next();
+  }
+  return jsonError(res, 401, 'unauthorized', 'Login required');
 }
 
 // count all incoming requests
@@ -241,6 +299,7 @@ function corsMiddleware (req, res, next) {
 app.use(corsMiddleware);
 
 const apiRouter = express.Router();
+const apiAuthRouter = express.Router();
 // All API endpoints are now mounted under `/api` for the external frontend SPA (legacy paths remain as compatibility aliases).
 
 function registerApiRoute (method, path, handlers, legacyPaths = []) {
@@ -276,6 +335,20 @@ app.get('/api/health', (req, res) => {
     timestamp: new Date().toISOString()
   });
 });
+
+apiAuthRouter.post('/login', (req, res) => {
+  res.status(501).json({ error: 'not_implemented', message: 'API login not yet available' });
+});
+
+apiAuthRouter.post('/logout', (req, res) => {
+  res.status(501).json({ error: 'not_implemented', message: 'API logout not yet available' });
+});
+
+apiAuthRouter.post('/refresh', (req, res) => {
+  res.status(501).json({ error: 'not_implemented', message: 'API token refresh not yet available' });
+});
+
+apiRouter.use('/auth', apiAuthRouter);
 
 async function broadcastStatus () {
   const queue = await getQueueLength();
@@ -425,10 +498,10 @@ app.get('/dashboard', (req, res) => {
   res.render('dashboard');
 });
 
-// auth middleware
-app.use(requireLogin);
+app.use('/api', apiAuthMiddleware, apiRouter);
 
-app.use('/api', apiRouter);
+// auth middleware for legacy/admin views
+app.use(requireLogin);
 
 function renderOrganizations (req, res) {
   res.render('organizations', { role: req.session.role });
@@ -625,7 +698,7 @@ app.get('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res) 
 
 function wantsJson (req) {
   const accept = req.headers.accept || '';
-  return accept.includes('application/json');
+  return req.isApiRequest || accept.includes('application/json');
 }
 
 app.get('/org/:id/upload', requireEditor, requireOrgAccess, (req, res) => {
@@ -724,7 +797,7 @@ async function createBotHandler (req, res) {
     'INSERT INTO whatsapp_bots (organization_id, assistant_id, name, phone, status) VALUES ($1,$2,$3,$4,$5) RETURNING *',
     [req.params.orgId, assistant_id, name || null, phone || null, 'stopped']
   );
-  if (req.headers.accept === 'application/json') {
+  if (req.isApiRequest || req.headers.accept === 'application/json') {
     return res.json(rows[0]);
   }
   res.redirect(`/org/${req.params.orgId}/bots/manage`);
@@ -733,7 +806,10 @@ async function createBotHandler (req, res) {
 async function startBotHandler (req, res) {
   const { rows } = await pool.query('SELECT * FROM whatsapp_bots WHERE id=$1', [req.params.botId]);
   const bot = rows[0];
-  if (!bot) return res.status(404).send('Not found');
+  if (!bot) {
+    if (req.isApiRequest) return jsonError(res, 404, 'not_found', 'Bot not found');
+    return res.status(404).send('Not found');
+  }
   await startBot(bot);
   res.json({ status: getBotStatus(bot.id) });
 }


### PR DESCRIPTION
## Summary
- add canonical SPA authentication refactor plan documenting risks, conflicts, and phases
- gate API authentication/authorization with a DISABLE_AUTH_FOR_API flag and JSON-only responses
- isolate API middleware from legacy CSRF/login flow and scaffold /api/auth endpoints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693551086fe08331a394ccc0f6123048)