### PR TITLE
Finalize SPA auth separation and scaffolding

### DIFF
--- a/docs/SPA_AUTH_REFACTOR_PLAN.md
+++ b/docs/SPA_AUTH_REFACTOR_PLAN.md
@@ -1,63 +1,62 @@
-# SPA Authentication Refactor Plan
+# SPA Auth Refactor Plan
 
-## Background & Problem Summary
-The current backend couples authentication to legacy EJS pages via Express sessions and CSRF, redirecting unauthenticated traffic to `/login` and expecting session-backed role checks. The SPA frontend issues stateless API calls without sessions, triggering 302 redirects and 403/401 errors. Mixed HTML and JSON responses further complicate integration, and CSRF/session assumptions bleed into `/api` routes.
+## 1. Background & Problem Summary
+- Legacy admin uses server-rendered HTML with session+CSRF; SPA needs JSON APIs without redirects.
+- Current mix of HTML and JSON in `/api` causes 302/HTML leakage to SPA.
+- Temporary auth bypass flag exists but needs documentation and hardening for SPA bring-up.
 
-## Detailed Technical Risks
-- Global session + CSRF middleware block API calls lacking cookies/tokens.
-- `requireLogin` redirects instead of returning JSON, breaking XHR clients.
-- Role/org/bot checks (`requireAdmin`, `requireEditor`, `requireOrgAccess`, `requireBotAccess`) rely solely on `req.session.*` and emit HTML/text responses.
-- Legacy handlers reuse redirects for success/failure even when mounted under `/api`.
-- No API-native login/logout endpoints; SPA cannot establish auth context.
-- Cookie settings assume same-site delivery; cross-origin SPA may not send them.
-- API and admin share middleware stack, so changes risk breaking the admin panel.
+## 2. Current Auth/CSRF Architecture (Legacy Model)
+- Session-based auth stored in `req.session.*` with role and organization scope.
+- Middlewares: `requireLogin`, `requireAdmin`, `requireEditor`, `requireOrgAccess`, `requireBotAccess`.
+- CSRF enforced globally on HTML routes via `csurf`; APIs were exempted ad-hoc.
+- Admin pages rely on redirects and server-rendered templates under mixed paths.
 
-## Conflict Inventory
-- All `/api/*` routes require legacy session + CSRF and redirect on missing auth.
-- POST/PUT/PATCH/DELETE blocked by CSRF token requirements not exposed to SPA.
-- Org/bot/user management endpoints expect `req.session.role`/`organization_id`.
-- Upload/bot creation handlers mix redirects and JSON depending on `Accept`.
-- Metrics endpoint intentionally unauthenticated; must remain so.
-- WebSocket clients piggyback on session auth but are unaudited for SPA flows.
+## 3. Conflict Inventory (Legacy vs SPA)
+- `/api/*` sometimes returns HTML/302 when session missing.
+- CSRF blocks JSON clients even when cookie-based auth is planned.
+- Role checks tied directly to session; no hook for token-derived `req.user`.
+- Admin and API share handlers, blurring HTML vs JSON expectations.
 
-## Full Remediation Plan
-- Introduce API-first auth layer (JWT or API cookie) alongside legacy sessions; expose `/api/auth/*` endpoints for SPA.
-- Guard `/api` with dedicated middleware that returns JSON (401/403) and can be bypassed via env flag during migration.
-- Keep legacy session + CSRF for EJS routes; decouple middleware stacks so admin and API evolve independently.
-- Normalize `/api` responses to JSON `{ error, message }`; remove redirects/HTML from API code paths.
-- Embed role/org info in API auth context (e.g., `req.user`) to power authorization checks without session coupling.
-- Document CORS/cookie requirements and standardize error payloads.
-- Add auth-focused integration tests to prevent regressions.
+## 4. Target Architecture for SPA-Friendly Auth
+- Clear split: admin HTML under `/admin/*` (with legacy aliases), APIs under `/api/*` JSON-only.
+- Toggle `DISABLE_AUTH_FOR_API` to temporarily bypass auth for `/api/*` while keeping admin secured.
+- Future `apiAuthMiddleware` populates `req.user` for APIs (JWT/cookie ready) without CSRF.
+- CSRF retained for admin forms; `/api/*` designed to be CSRF-optional once API auth lands.
 
-## Step-by-Step Refactor Phases
-1. **Bridge (current change)**: Add `DISABLE_AUTH_FOR_API` flag to bypass auth/CSRF expectations on `/api`; introduce API middleware that emits JSON errors; preserve admin behavior.
-2. **API Auth Surface**: Scaffold `/api/auth/login|logout|refresh` endpoints; decide on JWT vs. API cookie; wire middleware to validate tokens and populate `req.user`.
-3. **Route Normalization**: Update all `/api` handlers to return JSON only and rely on `req.user` for roles/org access; keep legacy redirects for admin pages.
-4. **Hardening**: Remove bypass flag in production configs; enforce CORS/credentials, add rate limits/lockouts, and observability around auth failures.
+## 5. Detailed Refactor Plan
+- Harden bypass flag:
+  - Name: `DISABLE_AUTH_FOR_API`.
+  - When `true`, `/api/*` skips legacy auth/role checks; admin HTML still requires session+CSRF.
+- Separate routers:
+  - `adminRouter` for HTML with session+CSRF+role middlewares; mounted at `/admin` and legacy roots.
+  - `apiRouter` for JSON-only responses; never redirects.
+- Normalize API responses to `{ error, code?, details? }` and status codes (401/403/404/500).
+- Add `apiAuth.js` scaffolding exporting `apiAuthMiddleware`, `loginHandler`, `logoutHandler`, `meHandler`.
+- Prepare middlewares to read `req.user` (future token context) while keeping session fallback.
+- Split HTML vs API handlers where mixed; keep admin pages rendering views, APIs returning JSON only.
 
-## Backward Compatibility Considerations
-- Legacy `/login`, admin pages, and CSRF-protected forms remain unchanged.
-- Session-based role checks stay active for non-API routes.
-- Metrics/WebSocket behavior preserved; new API auth runs alongside existing sessions.
-- Env flag defaults to secure mode; opting in is explicit and documented.
+## 6. Migration / Transition Strategy
+- Introduce `/admin/*` aliases while preserving existing paths to avoid breaking bookmarks.
+- Keep session+CSRF auth for admin; allow SPA to call `/api/*` with bypass during integration.
+- Gradually implement real API auth inside `apiAuthMiddleware` and handlers without changing routes.
 
-## API Contract Adjustments
-- Standardize error payloads: `{ error: 'unauthorized'|'forbidden'|..., message: '...' }` with status codes 401/403 for auth issues.
-- `/api` must never issue redirects or HTML; responses are JSON or status-only.
-- Future `/api/auth/*` endpoints will exchange credentials for tokens/cookies and return user/role metadata.
+## 7. Backward Compatibility & Risk Mitigation
+- Legacy admin routes remain reachable via old paths plus `/admin/*` aliases.
+- No DB schema changes; session-based auth untouched for admin.
+- Bypass flag defaults to secure mode (auth enforced) when unset/false.
+- Clear comments around bypass to avoid accidental production use.
 
-## Testing Plan
-- Unit tests for API auth middleware: unauthorized, forbidden, bypass flag behavior, and role/org access checks.
-- Integration tests for representative `/api` routes ensuring JSON errors and no redirects.
-- Regression tests for legacy admin flows (CSRF tokens, redirects) to confirm isolation.
+## 8. Testing & Validation Strategy
+- Manual checks while SPA integrates:
+  - `/api/organizations` and `/api/bots` with `DISABLE_AUTH_FOR_API=true` (no session required).
+  - Same endpoints with flag unset (legacy auth enforced; expect 401/403 JSON).
+  - `/login` and other admin pages remain session/CSRF protected.
+  - Ensure `/api/*` never returns 302/HTML.
+- `docker compose up -d --build` should still start successfully.
 
-## Migration Notes
-- Deploy with `DISABLE_AUTH_FOR_API=true` only in non-prod to unblock SPA while frontend implements real login.
-- Coordinate SPA changes to consume `/api/auth/*` and send credentials (cookie or bearer token).
-- After SPA migration, disable the bypass and remove reliance on legacy session headers for API calls.
-
-## “Successful State” Definition
-- `/api/*` authenticated via API-first mechanism (token or API cookie), returning JSON-only responses with consistent error formats.
-- Legacy admin routes continue to use session + CSRF and redirects as before.
-- Role/org/bot checks read from unified `req.user` context, not legacy session-only fields.
-- No unexpected 302/403 responses for authorized SPA clients; metrics/WebSocket flows remain operational.
+## 9. "Done" Criteria
+- `DISABLE_AUTH_FOR_API` documented and enforced for `/api/*` only.
+- Admin HTML isolated under `/admin/*` + legacy aliases; still session+CSRF protected.
+- `/api/*` handlers return JSON exclusively with normalized error shapes.
+- API auth scaffolding available at `/api/auth/login|logout|me` with 501 placeholders (or mock user when bypass enabled).
+- Middlewares ready to consume `req.user` from future API auth without breaking session behavior.

--- a/src/admin.js
+++ b/src/admin.js
@@ -34,8 +34,15 @@ const {
   getBotStatus,
   events: botEvents
 } = require('./botManager');
+const {
+  apiAuthMiddleware,
+  loginHandler: apiLoginHandler,
+  logoutHandler: apiLogoutHandler,
+  meHandler: apiMeHandler
+} = require('./apiAuth');
 
 const sessionSecret = process.env.SESSION_SECRET;
+// When true, API routes skip legacy auth/role checks. Admin HTML stays protected.
 const apiAuthBypass = process.env.DISABLE_AUTH_FOR_API === 'true';
 
 function isApiRequest (req) {
@@ -243,7 +250,7 @@ function requireLogin (req, res, next) {
   res.redirect('/login');
 }
 
-function apiAuthMiddleware (req, res, next) {
+function legacyApiSessionAuth (req, res, next) {
   if (!req.isApiRequest) return next();
   if (req.path.startsWith('/auth')) return next();
   if (isApiAuthDisabled(req)) return next();
@@ -309,13 +316,10 @@ app.use(corsMiddleware);
 
 const apiRouter = express.Router();
 const apiAuthRouter = express.Router();
-// All API endpoints are now mounted under `/api` for the external frontend SPA (legacy paths remain as compatibility aliases).
+// All API endpoints are mounted under `/api` for the external frontend SPA (no HTML fallbacks).
 
-function registerApiRoute (method, path, handlers, legacyPaths = []) {
+function registerApiRoute (method, path, handlers) {
   apiRouter[method](path, ...handlers);
-  legacyPaths.forEach(legacyPath => {
-    app[method](legacyPath, corsMiddleware, ...handlers);
-  });
 }
 
 // expose Prometheus metrics without auth
@@ -345,19 +349,12 @@ app.get('/api/health', (req, res) => {
   });
 });
 
-apiAuthRouter.post('/login', (req, res) => {
-  res.status(501).json({ error: 'not_implemented', message: 'API login not yet available' });
-});
-
-apiAuthRouter.post('/logout', (req, res) => {
-  res.status(501).json({ error: 'not_implemented', message: 'API logout not yet available' });
-});
-
-apiAuthRouter.post('/refresh', (req, res) => {
-  res.status(501).json({ error: 'not_implemented', message: 'API token refresh not yet available' });
-});
+apiAuthRouter.post('/login', apiLoginHandler);
+apiAuthRouter.post('/logout', apiLogoutHandler);
+apiAuthRouter.get('/me', apiMeHandler);
 
 apiRouter.use('/auth', apiAuthRouter);
+apiRouter.use(apiAuthMiddleware);
 
 async function broadcastStatus () {
   const queue = await getQueueLength();
@@ -380,11 +377,13 @@ async function broadcastStatus () {
 
 let statusInterval;
 
-app.get('/login', (req, res) => {
+const adminRouter = express.Router();
+
+adminRouter.get('/login', (req, res) => {
   res.render('login');
 });
 
-app.post('/login', async (req, res) => {
+adminRouter.post('/login', async (req, res) => {
   const { username, password, token } = req.body;
   const { rows } = await pool.query(
     'SELECT password_hash, role, totp_secret, organization_id FROM users WHERE username=$1',
@@ -415,7 +414,7 @@ app.post('/login', async (req, res) => {
   return res.redirect('/');
 });
 
-app.post('/setup-2fa', async (req, res) => {
+adminRouter.post('/setup-2fa', async (req, res) => {
   const { token } = req.body;
   const secret = req.session.temp_secret;
   const username = req.session.temp_user;
@@ -432,13 +431,13 @@ app.post('/setup-2fa', async (req, res) => {
   res.redirect('/');
 });
 
-app.get('/logout', (req, res) => {
+adminRouter.get('/logout', (req, res) => {
   req.session.destroy(() => {
     res.redirect('/login');
   });
 });
 
-app.get('/profile', requireLogin, async (req, res) => {
+adminRouter.get('/profile', requireLogin, async (req, res) => {
   try {
     const { rows } = await pool.query(
       'SELECT role, totp_secret FROM users WHERE username=$1',
@@ -456,7 +455,7 @@ app.get('/profile', requireLogin, async (req, res) => {
   }
 });
 
-app.get('/profile/setup-2fa', requireLogin, async (req, res) => {
+adminRouter.get('/profile/setup-2fa', requireLogin, async (req, res) => {
   try {
     const { rows } = await pool.query(
       'SELECT totp_secret FROM users WHERE username=$1',
@@ -474,7 +473,7 @@ app.get('/profile/setup-2fa', requireLogin, async (req, res) => {
   }
 });
 
-app.post('/profile/enable-2fa', requireLogin, async (req, res) => {
+adminRouter.post('/profile/enable-2fa', requireLogin, async (req, res) => {
   const { token } = req.body;
   const secret = req.session.temp_secret;
   const { rows } = await pool.query(
@@ -493,37 +492,37 @@ app.post('/profile/enable-2fa', requireLogin, async (req, res) => {
   res.redirect('/profile');
 });
 
-app.post('/profile/disable-2fa', requireLogin, async (req, res) => {
+adminRouter.post('/profile/disable-2fa', requireLogin, async (req, res) => {
   await pool.query('UPDATE users SET totp_secret=NULL WHERE username=$1', [req.session.user]);
   req.session.alert = { type: 'success', message: '2FA disabled' };
   res.redirect('/profile');
 });
 
-app.get('/stats', (req, res) => {
+adminRouter.get('/stats', (req, res) => {
   res.render('stats');
 });
 
-app.get('/dashboard', (req, res) => {
+adminRouter.get('/dashboard', (req, res) => {
   res.render('dashboard');
 });
 
-app.use('/api', apiAuthMiddleware, apiRouter);
+app.use('/api', legacyApiSessionAuth, apiRouter);
 
 // auth middleware for legacy/admin views
-app.use(requireLogin);
+adminRouter.use(requireLogin);
 
 function renderOrganizations (req, res) {
   res.render('organizations', { role: req.session.role });
 }
 
-app.get('/', requireEditor, renderOrganizations);
-app.get('/organizations', requireEditor, renderOrganizations);
+adminRouter.get('/', requireEditor, renderOrganizations);
+adminRouter.get('/organizations', requireEditor, renderOrganizations);
 
-app.get('/org/new', requireEditor, (req, res) => {
+adminRouter.get('/org/new', requireEditor, (req, res) => {
   res.render('newOrg');
 });
 
-app.post('/org/new', requireEditor, async (req, res) => {
+adminRouter.post('/org/new', requireEditor, async (req, res) => {
   const { name, phone, instructions, language, working_hours_start, working_hours_end } = req.body;
   await createOrganization(
     name,
@@ -690,7 +689,7 @@ registerApiRoute('post', '/organizations', [requireAdmin, createOrganizationHand
 registerApiRoute('put', '/organizations/:id', [requireEditor, requireOrgAccess, updateOrganizationHandler]);
 registerApiRoute('delete', '/organizations/:id', [requireEditor, requireOrgAccess, deactivateOrganizationHandler]);
 
-app.post('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.post('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res) => {
   const { instructions } = req.body;
   if (instructions !== undefined) {
     await pool.query('UPDATE organizations SET instructions=$1 WHERE id=$2', [instructions, req.params.id]);
@@ -699,7 +698,7 @@ app.post('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res)
   res.redirect('/');
 });
 
-app.get('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.get('/org/:id/assistant', requireEditor, requireOrgAccess, async (req, res) => {
   const { rows } = await pool.query('SELECT instructions FROM organizations WHERE id=$1', [req.params.id]);
   const instructions = rows[0]?.instructions || '';
   res.render('createAssistant', { orgId: req.params.id, instructions });
@@ -710,7 +709,7 @@ function wantsJson (req) {
   return req.isApiRequest || accept.includes('application/json');
 }
 
-app.get('/org/:id/upload', requireEditor, requireOrgAccess, (req, res) => {
+adminRouter.get('/org/:id/upload', requireEditor, requireOrgAccess, (req, res) => {
   res.render('upload', {
     orgId: req.params.id,
     error: null,
@@ -753,11 +752,10 @@ async function uploadOrganizationFileHandler (req, res) {
   }
 }
 
-registerApiRoute('post', '/organizations/:id/upload', [requireEditor, requireOrgAccess, uploadOrganizationFileHandler], [
-  '/org/:id/upload'
-]);
+registerApiRoute('post', '/organizations/:id/upload', [requireEditor, requireOrgAccess, uploadOrganizationFileHandler]);
+adminRouter.post('/org/:id/upload', requireEditor, requireOrgAccess, uploadOrganizationFileHandler);
 
-app.get('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.get('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => {
   const { rows } = await pool.query(
     'SELECT name, working_hours_start, working_hours_end FROM organizations WHERE id=$1',
     [req.params.id]
@@ -771,7 +769,7 @@ app.get('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => {
   });
 });
 
-app.post('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.post('/org/:id/hours', requireEditor, requireOrgAccess, async (req, res) => {
   const { working_hours_start, working_hours_end } = req.body;
   await pool.query(
     'UPDATE organizations SET working_hours_start=$1, working_hours_end=$2 WHERE id=$3',
@@ -788,7 +786,7 @@ async function listBotsHandler (req, res) {
   res.json(rows);
 }
 
-app.get('/org/:orgId/bots/manage', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.get('/org/:orgId/bots/manage', requireEditor, requireOrgAccess, async (req, res) => {
   const { rows } = await pool.query(
     'SELECT id, name, assistant_id, status FROM whatsapp_bots WHERE organization_id=$1',
     [req.params.orgId]
@@ -796,19 +794,25 @@ app.get('/org/:orgId/bots/manage', requireEditor, requireOrgAccess, async (req, 
   res.render('bots', { orgId: req.params.orgId, bots: rows, role: req.session.role });
 });
 
-app.get('/org/:orgId/bots/new', requireEditor, requireOrgAccess, (req, res) => {
+adminRouter.get('/org/:orgId/bots/new', requireEditor, requireOrgAccess, (req, res) => {
   res.render('newBot', { orgId: req.params.orgId });
 });
 
-async function createBotHandler (req, res) {
-  const { assistant_id, name, phone } = req.body;
+async function createBotRecord (orgId, assistantId, name, phone) {
   const { rows } = await pool.query(
     'INSERT INTO whatsapp_bots (organization_id, assistant_id, name, phone, status) VALUES ($1,$2,$3,$4,$5) RETURNING *',
-    [req.params.orgId, assistant_id, name || null, phone || null, 'stopped']
+    [orgId, assistantId, name || null, phone || null, 'stopped']
   );
-  if (req.isApiRequest || req.headers.accept === 'application/json') {
-    return res.json(rows[0]);
-  }
+  return rows[0];
+}
+
+async function createBotHandler (req, res) {
+  const bot = await createBotRecord(req.params.orgId, req.body.assistant_id, req.body.name, req.body.phone);
+  res.status(201).json(bot);
+}
+
+async function createBotAdminHandler (req, res) {
+  await createBotRecord(req.params.orgId, req.body.assistant_id, req.body.name, req.body.phone);
   res.redirect(`/org/${req.params.orgId}/bots/manage`);
 }
 
@@ -828,38 +832,48 @@ async function stopBotHandler (req, res) {
   res.json({ status: 'stopped' });
 }
 
+async function startBotAdminHandler (req, res) {
+  const { rows } = await pool.query('SELECT * FROM whatsapp_bots WHERE id=$1', [req.params.botId]);
+  const bot = rows[0];
+  if (!bot) return res.status(404).send('Not found');
+  await startBot(bot);
+  res.redirect(`/org/${bot.organization_id}/bots/manage`);
+}
+
+async function stopBotAdminHandler (req, res) {
+  stopBot(req.params.botId);
+  res.redirect('back');
+}
+
 async function botStatusHandler (req, res) {
   res.json({ status: getBotStatus(req.params.botId) });
 }
 
-registerApiRoute('get', '/organizations/:orgId/bots', [requireEditor, requireOrgAccess, listBotsHandler], [
-  '/org/:orgId/bots'
-]);
-registerApiRoute('post', '/organizations/:orgId/bots', [requireEditor, requireOrgAccess, createBotHandler], [
-  '/org/:orgId/bots'
-]);
-registerApiRoute('post', '/bots/:botId/start', [requireEditor, requireBotAccess, startBotHandler], [
-  '/bot/:botId/start'
-]);
-registerApiRoute('post', '/bots/:botId/stop', [requireEditor, requireBotAccess, stopBotHandler], [
-  '/bot/:botId/stop'
-]);
-registerApiRoute('get', '/bots/:botId/status', [requireEditor, requireBotAccess, botStatusHandler], [
-  '/bot/:botId/status'
-]);
+registerApiRoute('get', '/organizations/:orgId/bots', [requireEditor, requireOrgAccess, listBotsHandler]);
+registerApiRoute('post', '/organizations/:orgId/bots', [requireEditor, requireOrgAccess, createBotHandler]);
+registerApiRoute('post', '/bots/:botId/start', [requireEditor, requireBotAccess, startBotHandler]);
+registerApiRoute('post', '/bots/:botId/stop', [requireEditor, requireBotAccess, stopBotHandler]);
+registerApiRoute('get', '/bots/:botId/status', [requireEditor, requireBotAccess, botStatusHandler]);
+adminRouter.post('/org/:orgId/bots', requireEditor, requireOrgAccess, createBotAdminHandler);
+adminRouter.post('/bot/:botId/start', requireEditor, requireBotAccess, startBotAdminHandler);
+adminRouter.post('/bot/:botId/stop', requireEditor, requireBotAccess, stopBotAdminHandler);
+adminRouter.get('/bot/:botId/status', requireEditor, requireBotAccess, async (req, res) => {
+  const status = getBotStatus(req.params.botId);
+  res.json({ status });
+});
 
-app.get('/users', requireAdmin, async (req, res) => {
+adminRouter.get('/users', requireAdmin, async (req, res) => {
   const { rows } = await pool.query('SELECT id, username, role, organization_id FROM users ORDER BY id');
   const orgs = await listOrganizations();
   res.render('users', { users: rows, orgs });
 });
 
-app.get('/users/new', requireAdmin, async (req, res) => {
+adminRouter.get('/users/new', requireAdmin, async (req, res) => {
   const orgs = await listOrganizations();
   res.render('newUser', { orgs });
 });
 
-app.post('/users/new', requireAdmin, async (req, res) => {
+adminRouter.post('/users/new', requireAdmin, async (req, res) => {
   const { username, password, role, organization_id } = req.body;
   const hash = await bcrypt.hash(password, 10);
   await pool.query(
@@ -869,19 +883,19 @@ app.post('/users/new', requireAdmin, async (req, res) => {
   res.redirect('/users');
 });
 
-app.post('/users/:id/role', requireAdmin, async (req, res) => {
+adminRouter.post('/users/:id/role', requireAdmin, async (req, res) => {
   const { role, organization_id } = req.body;
   await pool.query('UPDATE users SET role=$1, organization_id=$2 WHERE id=$3', [role, organization_id || null, req.params.id]);
   res.redirect('/users');
 });
 
-app.post('/users/:id/disable-2fa', requireAdmin, async (req, res) => {
+adminRouter.post('/users/:id/disable-2fa', requireAdmin, async (req, res) => {
   await pool.query('UPDATE users SET totp_secret=NULL WHERE id=$1', [req.params.id]);
   req.session.alert = { type: 'success', message: '2FA disabled for user' };
   res.redirect('/users');
 });
 
-app.get('/schedule/new', requireEditor, async (req, res) => {
+adminRouter.get('/schedule/new', requireEditor, async (req, res) => {
   let orgs = await listOrganizations();
   if (req.session.role !== 'admin') {
     orgs = orgs.filter(o => o.id === req.session.organization_id);
@@ -889,7 +903,7 @@ app.get('/schedule/new', requireEditor, async (req, res) => {
   res.render('newSchedule', { orgs });
 });
 
-app.post('/schedule/new', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.post('/schedule/new', requireEditor, requireOrgAccess, async (req, res) => {
   const { organization_id, phone, text, send_at } = req.body;
   await pool.query(
     'INSERT INTO scheduled_messages (organization_id, phone, text, send_at) VALUES ($1,$2,$3,$4)',
@@ -898,7 +912,7 @@ app.post('/schedule/new', requireEditor, requireOrgAccess, async (req, res) => {
   res.redirect('/');
 });
 
-app.get('/broadcast', requireEditor, async (req, res) => {
+adminRouter.get('/broadcast', requireEditor, async (req, res) => {
   let orgs = await listOrganizations();
   if (req.session.role !== 'admin') {
     orgs = orgs.filter(o => o.id === req.session.organization_id);
@@ -906,7 +920,7 @@ app.get('/broadcast', requireEditor, async (req, res) => {
   res.render('broadcast', { orgs });
 });
 
-app.post('/broadcast', requireEditor, requireOrgAccess, async (req, res) => {
+adminRouter.post('/broadcast', requireEditor, requireOrgAccess, async (req, res) => {
   const { organization_id, phones, text } = req.body;
   let list = [];
   if (phones) {
@@ -929,11 +943,11 @@ app.post('/broadcast', requireEditor, requireOrgAccess, async (req, res) => {
   res.redirect('/');
 });
 
-app.get('/messages', requireEditor, (req, res) => {
+adminRouter.get('/messages', requireEditor, (req, res) => {
   res.render('messages');
 });
 
-app.post('/messages', requireEditor, async (req, res) => {
+adminRouter.post('/messages', requireEditor, async (req, res) => {
   const { phone, from, to, export: exportType } = req.body;
   const conditions = [];
   const params = [];
@@ -1008,12 +1022,12 @@ app.post('/messages', requireEditor, async (req, res) => {
   res.render('messageResults', { results: rows, summaries, phone, from, to });
 });
 
-app.post('/conversations/:id/escalate', requireAdmin, async (req, res) => {
+adminRouter.post('/conversations/:id/escalate', requireAdmin, async (req, res) => {
   await pool.query('UPDATE conversations SET escalated=TRUE WHERE id=$1', [req.params.id]);
   res.redirect('back');
 });
 
-app.get('/usage', requireAdmin, async (req, res) => {
+adminRouter.get('/usage', requireAdmin, async (req, res) => {
   const { rows } = await pool.query(
     `SELECT o.name, DATE(u.created_at) AS date,
             SUM(u.tokens_prompt) AS tokens_prompt,
@@ -1026,7 +1040,7 @@ app.get('/usage', requireAdmin, async (req, res) => {
   res.render('usage', { stats: rows });
 });
 
-app.get('/analytics', requireAdmin, async (req, res) => {
+adminRouter.get('/analytics', requireAdmin, async (req, res) => {
   const { rows } = await pool.query(
     `SELECT DATE(created_at) AS date, AVG(response_time_ms) AS avg_response
        FROM conversation_stats
@@ -1036,25 +1050,28 @@ app.get('/analytics', requireAdmin, async (req, res) => {
   res.render('analytics', { stats: rows });
 });
 
-app.get('/unanswered', requireAdmin, async (req, res) => {
+adminRouter.get('/unanswered', requireAdmin, async (req, res) => {
   const { rows } = await pool.query(
     'SELECT phone, message, created_at FROM unanswered_questions ORDER BY created_at DESC'
   );
   res.render('unanswered', { alerts: rows });
 });
 
-app.get('/faq', requireAdmin, async (req, res) => {
+adminRouter.get('/faq', requireAdmin, async (req, res) => {
   const { rows } = await pool.query(
     'SELECT id, question, count FROM faq_suggestions ORDER BY count DESC'
   );
   res.render('faq', { faqs: rows });
 });
 
-app.post('/faq/:id/delete', requireAdmin, async (req, res) => {
+adminRouter.post('/faq/:id/delete', requireAdmin, async (req, res) => {
   await pool.query('DELETE FROM faq_suggestions WHERE id=$1', [req.params.id]);
   req.session.alert = { type: 'success', message: 'FAQ entry deleted' };
   res.redirect('/faq');
 });
+
+app.use('/admin', adminRouter);
+app.use('/', adminRouter);
 
 app.use((err, req, res, next) => {
   if (err && err.code === 'EBADCSRFTOKEN') {

--- a/src/apiAuth.js
+++ b/src/apiAuth.js
@@ -1,0 +1,51 @@
+const apiAuthBypass = process.env.DISABLE_AUTH_FOR_API === 'true';
+
+function buildMockUser () {
+  return {
+    username: 'spa-demo',
+    role: 'admin',
+    organization_id: null
+  };
+}
+
+function apiAuthMiddleware (req, res, next) {
+  if (req.path.startsWith('/auth')) return next();
+  if (apiAuthBypass) return next();
+  if (req.session?.user) {
+    req.user = {
+      username: req.session.user,
+      role: req.session.role,
+      organization_id: req.session.organization_id
+    };
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized', code: 'ERR_UNAUTHORIZED' });
+}
+
+function loginHandler (_req, res) {
+  if (apiAuthBypass) {
+    return res.status(200).json({ user: buildMockUser(), message: 'Auth bypass enabled (development only)' });
+  }
+  return res.status(501).json({ error: 'Not implemented yet', code: 'ERR_NOT_IMPLEMENTED' });
+}
+
+function logoutHandler (_req, res) {
+  if (apiAuthBypass) {
+    return res.status(200).json({ message: 'Logged out (noop with bypass)' });
+  }
+  return res.status(501).json({ error: 'Not implemented yet', code: 'ERR_NOT_IMPLEMENTED' });
+}
+
+function meHandler (_req, res) {
+  if (apiAuthBypass) {
+    return res.status(200).json({ user: buildMockUser(), bypass: true });
+  }
+  return res.status(501).json({ error: 'Not implemented yet', code: 'ERR_NOT_IMPLEMENTED' });
+}
+
+module.exports = {
+  apiAuthMiddleware,
+  loginHandler,
+  logoutHandler,
+  meHandler
+};


### PR DESCRIPTION
## Summary
- add SPA_AUTH_REFACTOR_PLAN to document SPA-ready auth strategy and bypass behavior
- add apiAuth scaffolding and route wiring for upcoming API authentication
- separate admin HTML routes from /api JSON paths, normalize bot/org API flows, and retain CSRF/session protection for admin

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693559b2dc608331ba486f5dffb7bb4b)